### PR TITLE
Add apply interest feature that rewards customer loyalty

### DIFF
--- a/src/main/java/net/testudobank/MvcController.java
+++ b/src/main/java/net/testudobank/MvcController.java
@@ -22,7 +22,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 @Controller
 public class MvcController {
-  
+
   // A simplified JDBC client that is injected with the login credentials
   // specified in /src/main/resources/application.properties
   private JdbcTemplate jdbcTemplate;
@@ -31,7 +31,8 @@ public class MvcController {
   private CryptoPriceClient cryptoPriceClient;
 
   // Formatter for converting Java Dates to SQL-compatible DATETIME Strings
-  private static java.text.SimpleDateFormat SQL_DATETIME_FORMATTER = new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+  private static java.text.SimpleDateFormat SQL_DATETIME_FORMATTER = new java.text.SimpleDateFormat(
+      "yyyy-MM-dd HH:mm:ss");
 
   //// CONSTANT LITERALS ////
   public final static double INTEREST_RATE = 1.02;
@@ -47,6 +48,7 @@ public class MvcController {
   public static String TRANSACTION_HISTORY_TRANSFER_RECEIVE_ACTION = "TransferReceive";
   public static String TRANSACTION_HISTORY_CRYPTO_SELL_ACTION = "CryptoSell";
   public static String TRANSACTION_HISTORY_CRYPTO_BUY_ACTION = "CryptoBuy";
+  public static String TRANSACTION_HISTORY_APPLY_INTEREST_ACTION = "ApplyInterest";
   public static String CRYPTO_HISTORY_SELL_ACTION = "Sell";
   public static String CRYPTO_HISTORY_BUY_ACTION = "Buy";
   public static Set<String> SUPPORTED_CRYPTOCURRENCIES = new HashSet<>(Arrays.asList("ETH", "SOL"));
@@ -65,10 +67,10 @@ public class MvcController {
    * @param model
    * @return "welcome" page
    */
-	@GetMapping("/")
-	public String showWelcome(Model model) {
-		return "welcome";
-	}
+  @GetMapping("/")
+  public String showWelcome(Model model) {
+    return "welcome";
+  }
 
   /**
    * HTML GET request handler that serves the "login_form" page to the user.
@@ -79,12 +81,12 @@ public class MvcController {
    * @return "login_form" page
    */
   @GetMapping("/login")
-	public String showLoginForm(Model model) {
-		User user = new User();
+  public String showLoginForm(Model model) {
+    User user = new User();
     model.addAttribute("user", user);
 
-		return "login_form";
-	}
+    return "login_form";
+  }
 
   /**
    * HTML GET request handler that serves the "deposit_form" page to the user.
@@ -95,11 +97,11 @@ public class MvcController {
    * @return "deposit_form" page
    */
   @GetMapping("/deposit")
-	public String showDepositForm(Model model) {
+  public String showDepositForm(Model model) {
     User user = new User();
-		model.addAttribute("user", user);
-		return "deposit_form";
-	}
+    model.addAttribute("user", user);
+    return "deposit_form";
+  }
 
   /**
    * HTML GET request handler that serves the "withdraw_form" page to the user.
@@ -110,11 +112,11 @@ public class MvcController {
    * @return "withdraw_form" page
    */
   @GetMapping("/withdraw")
-	public String showWithdrawForm(Model model) {
+  public String showWithdrawForm(Model model) {
     User user = new User();
-		model.addAttribute("user", user);
-		return "withdraw_form";
-	}
+    model.addAttribute("user", user);
+    return "withdraw_form";
+  }
 
   /**
    * HTML GET request handler that serves the "dispute_form" page to the user.
@@ -125,11 +127,11 @@ public class MvcController {
    * @return "dispute_form" page
    */
   @GetMapping("/dispute")
-	public String showDisputeForm(Model model) {
+  public String showDisputeForm(Model model) {
     User user = new User();
-		model.addAttribute("user", user);
-		return "dispute_form";
-	}
+    model.addAttribute("user", user);
+    return "dispute_form";
+  }
 
   /**
    * HTML GET request handler that serves the "transfer_form" page to the user.
@@ -140,11 +142,11 @@ public class MvcController {
    * @return "dispute_form" page
    */
   @GetMapping("/transfer")
-	public String showTransferForm(Model model) {
+  public String showTransferForm(Model model) {
     User user = new User();
-		model.addAttribute("user", user);
-		return "transfer_form";
-	}
+    model.addAttribute("user", user);
+    return "transfer_form";
+  }
 
   /**
    * HTML GET request handler that serves the "buycrypto_form" page to the user.
@@ -155,13 +157,13 @@ public class MvcController {
    * @return "buycrypto_form" page
    */
   @GetMapping("/buycrypto")
-	public String showBuyCryptoForm(Model model) {
+  public String showBuyCryptoForm(Model model) {
     User user = new User();
     user.setEthPrice(cryptoPriceClient.getCurrentEthValue());
     user.setSolPrice(cryptoPriceClient.getCurrentSolValue());
-		model.addAttribute("user", user);
-		return "buycrypto_form";
-	}
+    model.addAttribute("user", user);
+    return "buycrypto_form";
+  }
 
   /**
    * HTML GET request handler that serves the "sellcrypto_form" page to the user.
@@ -172,38 +174,42 @@ public class MvcController {
    * @return "sellcrypto_form" page
    */
   @GetMapping("/sellcrypto")
-	public String showSellCryptoForm(Model model) {
+  public String showSellCryptoForm(Model model) {
     User user = new User();
     user.setEthPrice(cryptoPriceClient.getCurrentEthValue());
     user.setSolPrice(cryptoPriceClient.getCurrentSolValue());
-		model.addAttribute("user", user);
-		return "sellcrypto_form";
-	}
+    model.addAttribute("user", user);
+    return "sellcrypto_form";
+  }
 
   //// HELPER METHODS ////
 
   /**
-   * Helper method that queries the MySQL DB for the customer account info (First Name, Last Name, and Balance)
-   * and adds these values to the `user` Model Attribute so that they can be displayed in the "account_info" page.
+   * Helper method that queries the MySQL DB for the customer account info (First
+   * Name, Last Name, and Balance)
+   * and adds these values to the `user` Model Attribute so that they can be
+   * displayed in the "account_info" page.
    * 
    * @param user
    */
   private void updateAccountInfo(User user) {
-    List<Map<String,Object>> overdraftLogs = TestudoBankRepository.getOverdraftLogs(jdbcTemplate, user.getUsername());
+    List<Map<String, Object>> overdraftLogs = TestudoBankRepository.getOverdraftLogs(jdbcTemplate, user.getUsername());
     String logs = HTML_LINE_BREAK;
-    for(Map<String, Object> overdraftLog : overdraftLogs){
+    for (Map<String, Object> overdraftLog : overdraftLogs) {
       logs += overdraftLog + HTML_LINE_BREAK;
     }
 
-    List<Map<String,Object>> transactionLogs = TestudoBankRepository.getRecentTransactions(jdbcTemplate, user.getUsername(), MAX_NUM_TRANSACTIONS_DISPLAYED);
+    List<Map<String, Object>> transactionLogs = TestudoBankRepository.getRecentTransactions(jdbcTemplate,
+        user.getUsername(), MAX_NUM_TRANSACTIONS_DISPLAYED);
     String transactionHistoryOutput = HTML_LINE_BREAK;
-    for(Map<String, Object> transactionLog : transactionLogs){
+    for (Map<String, Object> transactionLog : transactionLogs) {
       transactionHistoryOutput += transactionLog + HTML_LINE_BREAK;
     }
 
-    List<Map<String,Object>> transferLogs = TestudoBankRepository.getTransferLogs(jdbcTemplate, user.getUsername(), MAX_NUM_TRANSFERS_DISPLAYED);
+    List<Map<String, Object>> transferLogs = TestudoBankRepository.getTransferLogs(jdbcTemplate, user.getUsername(),
+        MAX_NUM_TRANSFERS_DISPLAYED);
     String transferHistoryOutput = HTML_LINE_BREAK;
-    for(Map<String, Object> transferLog : transferLogs){
+    for (Map<String, Object> transferLog : transferLogs) {
       transferHistoryOutput += transferLog + HTML_LINE_BREAK;
     }
 
@@ -213,40 +219,48 @@ public class MvcController {
       cryptoHistoryOutput.append(cryptoLog).append(HTML_LINE_BREAK);
     }
 
-    String getUserNameAndBalanceAndOverDraftBalanceSql = String.format("SELECT FirstName, LastName, Balance, OverdraftBalance, NumDepositsForInterest FROM Customers WHERE CustomerID='%s';", user.getUsername());
-    List<Map<String,Object>> queryResults = jdbcTemplate.queryForList(getUserNameAndBalanceAndOverDraftBalanceSql);
-    Map<String,Object> userData = queryResults.get(0);
+    String getUserNameAndBalanceAndOverDraftBalanceSql = String.format(
+        "SELECT FirstName, LastName, Balance, OverdraftBalance, NumDepositsForInterest FROM Customers WHERE CustomerID='%s';",
+        user.getUsername());
+    List<Map<String, Object>> queryResults = jdbcTemplate.queryForList(getUserNameAndBalanceAndOverDraftBalanceSql);
+    Map<String, Object> userData = queryResults.get(0);
 
-    // calculate total Crypto holdings balance by summing balance of each supported cryptocurrency
+    // calculate total Crypto holdings balance by summing balance of each supported
+    // cryptocurrency
     double cryptoBalanceInDollars = 0;
     for (String cryptoName : MvcController.SUPPORTED_CRYPTOCURRENCIES) {
-      cryptoBalanceInDollars += TestudoBankRepository.getCustomerCryptoBalance(jdbcTemplate, user.getUsername(), cryptoName).orElse(0.0) * cryptoPriceClient.getCurrentCryptoValue(cryptoName);
+      cryptoBalanceInDollars += TestudoBankRepository
+          .getCustomerCryptoBalance(jdbcTemplate, user.getUsername(), cryptoName).orElse(0.0)
+          * cryptoPriceClient.getCurrentCryptoValue(cryptoName);
     }
 
-    user.setFirstName((String)userData.get("FirstName"));
-    user.setLastName((String)userData.get("LastName"));
-    user.setBalance((int)userData.get("Balance")/100.0);
-    double overDraftBalance = (int)userData.get("OverdraftBalance");
-    user.setOverDraftBalance(overDraftBalance/100);
+    user.setFirstName((String) userData.get("FirstName"));
+    user.setLastName((String) userData.get("LastName"));
+    user.setBalance((int) userData.get("Balance") / 100.0);
+    double overDraftBalance = (int) userData.get("OverdraftBalance");
+    user.setOverDraftBalance(overDraftBalance / 100);
     user.setCryptoBalanceUSD(cryptoBalanceInDollars);
     user.setLogs(logs);
     user.setTransactionHist(transactionHistoryOutput);
     user.setTransferHist(transferHistoryOutput);
     user.setCryptoHist(cryptoHistoryOutput.toString());
-    user.setEthBalance(TestudoBankRepository.getCustomerCryptoBalance(jdbcTemplate, user.getUsername(), "ETH").orElse(0.0));
-    user.setSolBalance(TestudoBankRepository.getCustomerCryptoBalance(jdbcTemplate, user.getUsername(), "SOL").orElse(0.0));
+    user.setEthBalance(
+        TestudoBankRepository.getCustomerCryptoBalance(jdbcTemplate, user.getUsername(), "ETH").orElse(0.0));
+    user.setSolBalance(
+        TestudoBankRepository.getCustomerCryptoBalance(jdbcTemplate, user.getUsername(), "SOL").orElse(0.0));
     user.setEthPrice(cryptoPriceClient.getCurrentEthValue());
     user.setSolPrice(cryptoPriceClient.getCurrentSolValue());
     user.setNumDepositsForInterest(user.getNumDepositsForInterest());
   }
 
-  // Converts dollar amounts in frontend to penny representation in backend MySQL DB
+  // Converts dollar amounts in frontend to penny representation in backend MySQL
+  // DB
   private static int convertDollarsToPennies(double dollarAmount) {
     return (int) (dollarAmount * 100);
   }
 
   // Converts LocalDateTime to Date variable
-  private static Date convertLocalDateTimeToDate(LocalDateTime ldt){
+  private static Date convertLocalDateTimeToDate(LocalDateTime ldt) {
     Date dateTime = Date.from(ldt.atZone(ZoneId.systemDefault()).toInstant());
     return dateTime;
   }
@@ -254,25 +268,31 @@ public class MvcController {
   // HTML POST HANDLERS ////
 
   /**
-   * HTML POST request handler that uses user input from Login Form page to determine 
+   * HTML POST request handler that uses user input from Login Form page to
+   * determine
    * login success or failure.
    * 
-   * Queries 'passwords' table in MySQL DB for the correct password associated with the
-   * username ID given by the user. Compares the user's password attempt with the correct
+   * Queries 'passwords' table in MySQL DB for the correct password associated
+   * with the
+   * username ID given by the user. Compares the user's password attempt with the
+   * correct
    * password.
    * 
-   * If the password attempt is correct, the "account_info" page is served to the customer
+   * If the password attempt is correct, the "account_info" page is served to the
+   * customer
    * with all account details retrieved from the MySQL DB.
    * 
-   * If the password attempt is incorrect, the user is redirected to the "welcome" page.
+   * If the password attempt is incorrect, the user is redirected to the "welcome"
+   * page.
    * 
    * @param user
-   * @return "account_info" page if login successful. Otherwise, redirect to "welcome" page.
+   * @return "account_info" page if login successful. Otherwise, redirect to
+   *         "welcome" page.
    */
   @PostMapping("/login")
-	public String submitLoginForm(@ModelAttribute("user") User user) {
+  public String submitLoginForm(@ModelAttribute("user") User user) {
     // Print user's existing fields for debugging
-		System.out.println(user);
+    System.out.println(user);
 
     String userID = user.getUsername();
     String userPasswordAttempt = user.getPassword();
@@ -287,7 +307,7 @@ public class MvcController {
     } else {
       return "welcome";
     }
-	}
+  }
 
   /**
    * HTML POST request handler for the Deposit Form page.
@@ -295,11 +315,13 @@ public class MvcController {
    * If the user is currently not in overdraft, the deposit amount is simply
    * added to the user's main balance.
    * 
-   * If the user is in overdraft, the deposit amount first pays off the overdraft balance,
+   * If the user is in overdraft, the deposit amount first pays off the overdraft
+   * balance,
    * and any excess deposit amount is added to the main balance.
    * 
    * @param user
-   * @return "account_info" page if valid deposit request. Otherwise, redirect to "welcome" page.
+   * @return "account_info" page if valid deposit request. Otherwise, redirect to
+   *         "welcome" page.
    */
   @PostMapping("/deposit")
   public String submitDeposit(@ModelAttribute("user") User user) {
@@ -314,9 +336,10 @@ public class MvcController {
       return "welcome";
     }
 
-    // If customer already has too many reversals, their account is frozen. Don't complete deposit.
+    // If customer already has too many reversals, their account is frozen. Don't
+    // complete deposit.
     int numOfReversals = TestudoBankRepository.getCustomerNumberOfReversals(jdbcTemplate, userID);
-    if (numOfReversals >= MAX_DISPUTES){
+    if (numOfReversals >= MAX_DISPUTES) {
       return "welcome";
     }
 
@@ -325,17 +348,22 @@ public class MvcController {
     if (userDepositAmt < 0) {
       return "welcome";
     }
-    
+
     //// Complete Deposit Transaction ////
-    int userDepositAmtInPennies = convertDollarsToPennies(userDepositAmt); // dollar amounts stored as pennies to avoid floating point errors
-    String currentTime = SQL_DATETIME_FORMATTER.format(new java.util.Date()); // use same timestamp for all logs created by this deposit
-    int userOverdraftBalanceInPennies = TestudoBankRepository.getCustomerOverdraftBalanceInPennies(jdbcTemplate, userID);
+    int userDepositAmtInPennies = convertDollarsToPennies(userDepositAmt); // dollar amounts stored as pennies to avoid
+                                                                           // floating point errors
+    String currentTime = SQL_DATETIME_FORMATTER.format(new java.util.Date()); // use same timestamp for all logs created
+                                                                              // by this deposit
+    int userOverdraftBalanceInPennies = TestudoBankRepository.getCustomerOverdraftBalanceInPennies(jdbcTemplate,
+        userID);
     if (userOverdraftBalanceInPennies > 0) { // deposit will pay off overdraft first
-      // update overdraft balance in Customers table, and log the repayment in OverdraftLogs table.
+      // update overdraft balance in Customers table, and log the repayment in
+      // OverdraftLogs table.
       int newOverdraftBalanceInPennies = Math.max(userOverdraftBalanceInPennies - userDepositAmtInPennies, 0);
       TestudoBankRepository.setCustomerOverdraftBalance(jdbcTemplate, userID, newOverdraftBalanceInPennies);
-      TestudoBankRepository.insertRowToOverdraftLogsTable(jdbcTemplate, userID, currentTime, userDepositAmtInPennies, userOverdraftBalanceInPennies, newOverdraftBalanceInPennies);
-      
+      TestudoBankRepository.insertRowToOverdraftLogsTable(jdbcTemplate, userID, currentTime, userDepositAmtInPennies,
+          userOverdraftBalanceInPennies, newOverdraftBalanceInPennies);
+
       // add any excess deposit amount to main balance in Customers table
       if (userDepositAmtInPennies > userOverdraftBalanceInPennies) {
         int mainBalanceIncreaseAmtInPennies = userDepositAmtInPennies - userOverdraftBalanceInPennies;
@@ -347,36 +375,45 @@ public class MvcController {
     }
 
     // only adds deposit to transaction history if is not transfer
-    if (user.isTransfer()){
+    if (user.isTransfer()) {
       // Adds transaction recieve to transaction history
-      TestudoBankRepository.insertRowToTransactionHistoryTable(jdbcTemplate, userID, currentTime, TRANSACTION_HISTORY_TRANSFER_RECEIVE_ACTION, userDepositAmtInPennies);
+      TestudoBankRepository.insertRowToTransactionHistoryTable(jdbcTemplate, userID, currentTime,
+          TRANSACTION_HISTORY_TRANSFER_RECEIVE_ACTION, userDepositAmtInPennies);
     } else if (user.isCryptoTransaction()) {
-      TestudoBankRepository.insertRowToTransactionHistoryTable(jdbcTemplate, userID, currentTime, TRANSACTION_HISTORY_CRYPTO_SELL_ACTION, userDepositAmtInPennies);
+      TestudoBankRepository.insertRowToTransactionHistoryTable(jdbcTemplate, userID, currentTime,
+          TRANSACTION_HISTORY_CRYPTO_SELL_ACTION, userDepositAmtInPennies);
     } else {
       // Adds deposit to transaction history
-      TestudoBankRepository.insertRowToTransactionHistoryTable(jdbcTemplate, userID, currentTime, TRANSACTION_HISTORY_DEPOSIT_ACTION, userDepositAmtInPennies);
+      TestudoBankRepository.insertRowToTransactionHistoryTable(jdbcTemplate, userID, currentTime,
+          TRANSACTION_HISTORY_DEPOSIT_ACTION, userDepositAmtInPennies);
     }
 
-    // update Model so that View can access new main balance, overdraft balance, and logs
+    // update Model so that View can access new main balance, overdraft balance, and
+    // logs
     applyInterest(user);
     updateAccountInfo(user);
     return "account_info";
   }
-	
+
   /**
    * HTML POST request handler for the Withdraw Form page.
    * 
-   * If the user is not currently in overdraft and the withdraw amount does not exceed the user's
+   * If the user is not currently in overdraft and the withdraw amount does not
+   * exceed the user's
    * current main balance, the main balance is decremented by the amount specified
    * 
-   * If the withdraw amount exceeds the user's current main balance, the user's main balance is set to
-   * 0 and the user's overdraft balance becomes the excess withdraw amount with interest applied.
+   * If the withdraw amount exceeds the user's current main balance, the user's
+   * main balance is set to
+   * 0 and the user's overdraft balance becomes the excess withdraw amount with
+   * interest applied.
    * 
-   * If the user was already in overdraft, the entire withdraw amount with interest applied is added
+   * If the user was already in overdraft, the entire withdraw amount with
+   * interest applied is added
    * to the existing overdraft balance.
    * 
    * @param user
-   * @return "account_info" page if withdraw request is valid. Otherwise, redirect to "welcome" page.
+   * @return "account_info" page if withdraw request is valid. Otherwise, redirect
+   *         to "welcome" page.
    */
   @PostMapping("/withdraw")
   public String submitWithdraw(@ModelAttribute("user") User user) {
@@ -391,9 +428,10 @@ public class MvcController {
       return "welcome";
     }
 
-    // If customer already has too many reversals, their account is frozen. Don't complete deposit.
+    // If customer already has too many reversals, their account is frozen. Don't
+    // complete deposit.
     int numOfReversals = TestudoBankRepository.getCustomerNumberOfReversals(jdbcTemplate, userID);
-    if (numOfReversals >= MAX_DISPUTES){
+    if (numOfReversals >= MAX_DISPUTES) {
       return "welcome";
     }
 
@@ -404,23 +442,30 @@ public class MvcController {
     }
 
     //// Complete Withdraw Transaction ////
-    int userWithdrawAmtInPennies = convertDollarsToPennies(userWithdrawAmt); // dollar amounts stored as pennies to avoid floating point errors
-    String currentTime = SQL_DATETIME_FORMATTER.format(new java.util.Date()); // use same timestamp for all logs created by this deposit
+    int userWithdrawAmtInPennies = convertDollarsToPennies(userWithdrawAmt); // dollar amounts stored as pennies to
+                                                                             // avoid floating point errors
+    String currentTime = SQL_DATETIME_FORMATTER.format(new java.util.Date()); // use same timestamp for all logs created
+                                                                              // by this deposit
     int userBalanceInPennies = TestudoBankRepository.getCustomerCashBalanceInPennies(jdbcTemplate, userID);
-    int userOverdraftBalanceInPennies = TestudoBankRepository.getCustomerOverdraftBalanceInPennies(jdbcTemplate, userID);
-    if (userWithdrawAmtInPennies > userBalanceInPennies) { // if withdraw amount exceeds main balance, withdraw into overdraft with interest fee
+    int userOverdraftBalanceInPennies = TestudoBankRepository.getCustomerOverdraftBalanceInPennies(jdbcTemplate,
+        userID);
+    if (userWithdrawAmtInPennies > userBalanceInPennies) { // if withdraw amount exceeds main balance, withdraw into
+                                                           // overdraft with interest fee
       int excessWithdrawAmtInPennies = userWithdrawAmtInPennies - userBalanceInPennies;
-      int newOverdraftIncreaseAmtAfterInterestInPennies = (int)(excessWithdrawAmtInPennies * INTEREST_RATE);
+      int newOverdraftIncreaseAmtAfterInterestInPennies = (int) (excessWithdrawAmtInPennies * INTEREST_RATE);
       int newOverdraftBalanceInPennies = userOverdraftBalanceInPennies + newOverdraftIncreaseAmtAfterInterestInPennies;
 
-      // abort withdraw transaction if new overdraft balance exceeds max overdraft limit
-      // IMPORTANT: Compare new overdraft balance to max overdraft limit AFTER applying the interest rate!
+      // abort withdraw transaction if new overdraft balance exceeds max overdraft
+      // limit
+      // IMPORTANT: Compare new overdraft balance to max overdraft limit AFTER
+      // applying the interest rate!
       if (newOverdraftBalanceInPennies > MAX_OVERDRAFT_IN_PENNIES) {
         return "welcome";
       }
 
       // this is a valid withdraw into overdraft, so we can set Balance column to 0.
-      // OK to do this even if we were already in overdraft since main balance was already 0 anyways
+      // OK to do this even if we were already in overdraft since main balance was
+      // already 0 anyways
       TestudoBankRepository.setCustomerCashBalance(jdbcTemplate, userID, 0);
 
       // increase overdraft balance by the withdraw amount after interest
@@ -431,18 +476,21 @@ public class MvcController {
     }
 
     // only adds withdraw to transaction history if is not transfer
-    if (user.isTransfer()){
+    if (user.isTransfer()) {
       // Adds transfer send to transaction history
-      TestudoBankRepository.insertRowToTransactionHistoryTable(jdbcTemplate, userID, currentTime, TRANSACTION_HISTORY_TRANSFER_SEND_ACTION, userWithdrawAmtInPennies);
+      TestudoBankRepository.insertRowToTransactionHistoryTable(jdbcTemplate, userID, currentTime,
+          TRANSACTION_HISTORY_TRANSFER_SEND_ACTION, userWithdrawAmtInPennies);
     } else if (user.isCryptoTransaction()) {
-      TestudoBankRepository.insertRowToTransactionHistoryTable(jdbcTemplate, userID, currentTime, TRANSACTION_HISTORY_CRYPTO_BUY_ACTION, userWithdrawAmtInPennies);
+      TestudoBankRepository.insertRowToTransactionHistoryTable(jdbcTemplate, userID, currentTime,
+          TRANSACTION_HISTORY_CRYPTO_BUY_ACTION, userWithdrawAmtInPennies);
     } else {
       // Adds withdraw to transaction history
-      TestudoBankRepository.insertRowToTransactionHistoryTable(jdbcTemplate, userID, currentTime, TRANSACTION_HISTORY_WITHDRAW_ACTION, userWithdrawAmtInPennies);
+      TestudoBankRepository.insertRowToTransactionHistoryTable(jdbcTemplate, userID, currentTime,
+          TRANSACTION_HISTORY_WITHDRAW_ACTION, userWithdrawAmtInPennies);
     }
 
-  
-    // update Model so that View can access new main balance, overdraft balance, and logs
+    // update Model so that View can access new main balance, overdraft balance, and
+    // logs
     updateAccountInfo(user);
     return "account_info";
 
@@ -453,13 +501,16 @@ public class MvcController {
    * 
    * The same username+password handling from the login page is used.
    * 
-   * If the password attempt is correct, the transaction is reversed and the proper
+   * If the password attempt is correct, the transaction is reversed and the
+   * proper
    * balances are updated
    * 
-   * If the password attempt is incorrect, the user is redirected to the "welcome" page.
+   * If the password attempt is incorrect, the user is redirected to the "welcome"
+   * page.
    * 
    * @param user
-   * @return "account_info" page if login successful. Otherwise, redirect to "welcome" page.
+   * @return "account_info" page if login successful. Otherwise, redirect to
+   *         "welcome" page.
    */
   @PostMapping("/dispute")
   public String submitDispute(@ModelAttribute("user") User user) {
@@ -470,7 +521,7 @@ public class MvcController {
 
     String userID = user.getUsername();
     String userPasswordAttempt = user.getPassword();
-    
+
     String userPassword = TestudoBankRepository.getCustomerPassword(jdbcTemplate, userID);
 
     // unsuccessful login
@@ -483,10 +534,11 @@ public class MvcController {
     if (numOfReversals >= MAX_DISPUTES) {
       return "welcome";
     }
-    
+
     // Fetch 3 most recent transactions for this customer
-    List<Map<String,Object>> transactionLogs = TestudoBankRepository.getRecentTransactions(jdbcTemplate, userID, MAX_NUM_TRANSACTIONS_DISPLAYED);
-    
+    List<Map<String, Object>> transactionLogs = TestudoBankRepository.getRecentTransactions(jdbcTemplate, userID,
+        MAX_NUM_TRANSACTIONS_DISPLAYED);
+
     // Ensure customer has enough transactions to complete the reversal
     if (user.getNumTransactionsAgo() > transactionLogs.size()) {
       return "welcome";
@@ -497,7 +549,8 @@ public class MvcController {
 
     // Get balance and overdraft balance
     int userBalanceInPennies = TestudoBankRepository.getCustomerCashBalanceInPennies(jdbcTemplate, userID);
-    int userOverdraftBalanceInPennies = TestudoBankRepository.getCustomerOverdraftBalanceInPennies(jdbcTemplate, userID);
+    int userOverdraftBalanceInPennies = TestudoBankRepository.getCustomerOverdraftBalanceInPennies(jdbcTemplate,
+        userID);
 
     int reversalAmountInPennies = (int) logToReverse.get("Amount");
     double reversalAmount = reversalAmountInPennies / 100.0;
@@ -512,15 +565,20 @@ public class MvcController {
       submitWithdraw(user);
 
       // If reversing a deposit puts customer back in overdraft
-      if (reversalAmountInPennies > userBalanceInPennies){
+      if (reversalAmountInPennies > userBalanceInPennies) {
         // check if the reversed deposit helped pay off overdraft balance
-        // if it did, do not re-apply the interest rate after the reversal of the deposit since the customer was already in overdraft
-        String datetimeOfReversedDeposit = SQL_DATETIME_FORMATTER.format(convertLocalDateTimeToDate((LocalDateTime)logToReverse.get("Timestamp")));
-        List<Map<String,Object>> overdraftLogs = TestudoBankRepository.getOverdraftLogs(jdbcTemplate, userID, datetimeOfReversedDeposit);
+        // if it did, do not re-apply the interest rate after the reversal of the
+        // deposit since the customer was already in overdraft
+        String datetimeOfReversedDeposit = SQL_DATETIME_FORMATTER
+            .format(convertLocalDateTimeToDate((LocalDateTime) logToReverse.get("Timestamp")));
+        List<Map<String, Object>> overdraftLogs = TestudoBankRepository.getOverdraftLogs(jdbcTemplate, userID,
+            datetimeOfReversedDeposit);
 
         // fetch updated overdraft balance with extra interest rate applied
-        double updatedOverdraftBalanceInPennies = TestudoBankRepository.getCustomerOverdraftBalanceInPennies(jdbcTemplate, userID);
-        // reverse extra application of interest rate since customer was already in overdraft
+        double updatedOverdraftBalanceInPennies = TestudoBankRepository
+            .getCustomerOverdraftBalanceInPennies(jdbcTemplate, userID);
+        // reverse extra application of interest rate since customer was already in
+        // overdraft
         int newOverdraftBalanceInPennies = (int) (updatedOverdraftBalanceInPennies / 1.02);
 
         if (overdraftLogs.size() != 0) {
@@ -528,13 +586,13 @@ public class MvcController {
           TestudoBankRepository.deleteRowFromOverdraftLogsTable(jdbcTemplate, userID, datetimeOfReversedDeposit);
           TestudoBankRepository.setCustomerOverdraftBalance(jdbcTemplate, userID, newOverdraftBalanceInPennies);
         }
-      } 
+      }
     } else { // Case when reversing a withdraw, deposit the money instead
       user.setAmountToDeposit(reversalAmount);
       submitDeposit(user);
     }
 
-    // Adds to number of reversals only after a successful reversal 
+    // Adds to number of reversals only after a successful reversal
     numOfReversals++;
     TestudoBankRepository.setCustomerNumFraudReversals(jdbcTemplate, userID, numOfReversals);
 
@@ -548,22 +606,25 @@ public class MvcController {
    * 
    * The same username+password handling from the login page is used.
    * 
-   * If the password attempt is correct, the users transfer successfully goes through
+   * If the password attempt is correct, the users transfer successfully goes
+   * through
    * if it is a valid transfer. Both customers balances are properly updated.
    * 
-   * If the password attempt is incorrect, the user is redirected to the "welcome" page.
+   * If the password attempt is incorrect, the user is redirected to the "welcome"
+   * page.
    * 
-   * Transfer function is implemented by re-using deposit and withdraw handlers to 
+   * Transfer function is implemented by re-using deposit and withdraw handlers to
    * facilitate a transfer between 2 users.
    * 
    * @param user
-   * @return "account_info" page if login successful. Otherwise, redirect to "welcome" page.
+   * @return "account_info" page if login successful. Otherwise, redirect to
+   *         "welcome" page.
    */
   @PostMapping("/transfer")
   public String submitTransfer(@ModelAttribute("user") User sender) {
 
     // checks to see the customer you are transfering to exists
-    if (!TestudoBankRepository.doesCustomerExist(jdbcTemplate, sender.getTransferRecipientID())){
+    if (!TestudoBankRepository.doesCustomerExist(jdbcTemplate, sender.getTransferRecipientID())) {
       return "welcome";
     }
 
@@ -596,7 +657,7 @@ public class MvcController {
     }
 
     // case where customer tries to send money to themselves
-    if (sender.getTransferRecipientID().equals(senderUserID)){
+    if (sender.getTransferRecipientID().equals(senderUserID)) {
       return "welcome";
     }
 
@@ -607,9 +668,10 @@ public class MvcController {
     // negative transfer amount is not allowed
     if (transferAmount < 0) {
       return "welcome";
-    } 
-  
-    String currentTime = SQL_DATETIME_FORMATTER.format(new java.util.Date()); // use same timestamp for all logs created by this transfer
+    }
+
+    String currentTime = SQL_DATETIME_FORMATTER.format(new java.util.Date()); // use same timestamp for all logs created
+                                                                              // by this transfer
 
     // withdraw transfer amount from sender and deposit into recipient's account
     sender.setAmountToWithdraw(transferAmount);
@@ -619,7 +681,8 @@ public class MvcController {
     submitDeposit(recipient);
 
     // Inserting transfer into transfer history for both customers
-    TestudoBankRepository.insertRowToTransferLogsTable(jdbcTemplate, senderUserID, recipientUserID, currentTime, transferAmountInPennies);
+    TestudoBankRepository.insertRowToTransferLogsTable(jdbcTemplate, senderUserID, recipientUserID, currentTime,
+        transferAmountInPennies);
     updateAccountInfo(sender);
 
     return "account_info";
@@ -632,7 +695,8 @@ public class MvcController {
    * <p>
    * If the password attempt is correct, the user is not in overdraft,
    * and the purchase amount is a valid amount that does not exceed balance,
-   * the cost of the cryptocurrency in cash will be subtracted from the users balance,
+   * the cost of the cryptocurrency in cash will be subtracted from the users
+   * balance,
    * and cryptocurrency will be added to the users account
    * <p>
    * If the password attempt is incorrect or the amount to purchase is invalid,
@@ -641,7 +705,8 @@ public class MvcController {
    * Crypto purchase function is implemented by re-using withdraw handler.
    *
    * @param user
-   * @return "account_info" page if buy successful. Otherwise, redirect to "welcome" page.
+   * @return "account_info" page if buy successful. Otherwise, redirect to
+   *         "welcome" page.
    */
   @PostMapping("/buycrypto")
   public String buyCrypto(@ModelAttribute("user") User user) {
@@ -670,7 +735,8 @@ public class MvcController {
     }
 
     // cannot buy crypto while in overdraft
-    int userOverdraftBalanceInPennies = TestudoBankRepository.getCustomerOverdraftBalanceInPennies(jdbcTemplate, userID);
+    int userOverdraftBalanceInPennies = TestudoBankRepository.getCustomerOverdraftBalanceInPennies(jdbcTemplate,
+        userID);
     if (userOverdraftBalanceInPennies > 0) {
       return "welcome";
     }
@@ -698,18 +764,21 @@ public class MvcController {
     user.setAmountToWithdraw(costOfCryptoPurchaseInDollars);
     user.setCryptoTransaction(true);
 
-    // TODO: I don't like how this is dependent on a string return value. Withdraw logic should probably be extracted
+    // TODO: I don't like how this is dependent on a string return value. Withdraw
+    // logic should probably be extracted
     String withdrawResponse = submitWithdraw(user);
 
     if (withdrawResponse.equals("account_info")) {
 
-      // create an entry in CryptoHoldings table if customer is buying this Crypto for the first time.
+      // create an entry in CryptoHoldings table if customer is buying this Crypto for
+      // the first time.
       if (!TestudoBankRepository.getCustomerCryptoBalance(jdbcTemplate, userID, cryptoToBuy).isPresent()) {
         TestudoBankRepository.initCustomerCryptoBalance(jdbcTemplate, userID, cryptoToBuy);
       }
 
       TestudoBankRepository.increaseCustomerCryptoBalance(jdbcTemplate, userID, cryptoToBuy, cryptoAmountToBuy);
-      TestudoBankRepository.insertRowToCryptoLogsTable(jdbcTemplate, userID, cryptoToBuy, CRYPTO_HISTORY_BUY_ACTION, currentTime, cryptoAmountToBuy);
+      TestudoBankRepository.insertRowToCryptoLogsTable(jdbcTemplate, userID, cryptoToBuy, CRYPTO_HISTORY_BUY_ACTION,
+          currentTime, cryptoAmountToBuy);
 
       updateAccountInfo(user);
 
@@ -726,17 +795,21 @@ public class MvcController {
    * The same username+password handling from the login page is used.
    * <p>
    * If the password attempt is correct, and the purchase amount is a valid amount
-   * that does not exceed crypto balance, the cost of the cryptocurrency in cash will be
-   * added to the users cash balance, and cryptocurrency will be subtracted from the users account
+   * that does not exceed crypto balance, the cost of the cryptocurrency in cash
+   * will be
+   * added to the users cash balance, and cryptocurrency will be subtracted from
+   * the users account
    * <p>
    * If the password attempt is incorrect or the amount to purchase is invalid,
    * the user is redirected to the "welcome" page.
    * <p>
    * Crypto purchase function is implemented by re-using deposit handler.
-   * Logic of deposit (applying to overdraft, adding to balance, etc.) is delegated to this handler.
+   * Logic of deposit (applying to overdraft, adding to balance, etc.) is
+   * delegated to this handler.
    *
    * @param user
-   * @return "account_info" page if sell successful. Otherwise, redirect to "welcome" page.
+   * @return "account_info" page if sell successful. Otherwise, redirect to
+   *         "welcome" page.
    */
   @PostMapping("/sellcrypto")
   public String sellCrypto(@ModelAttribute("user") User user) {
@@ -782,13 +855,15 @@ public class MvcController {
     user.setAmountToDeposit(cryptoValueInDollars);
     user.setCryptoTransaction(true);
 
-    // TODO: I don't like how this is dependent on a string return value. Deposit logic should probably be extracted
+    // TODO: I don't like how this is dependent on a string return value. Deposit
+    // logic should probably be extracted
     String depositResponse = submitDeposit(user);
 
     if (depositResponse.equals("account_info")) {
 
       TestudoBankRepository.decreaseCustomerCryptoBalance(jdbcTemplate, userID, cryptoToBuy, cryptoAmountToSell);
-      TestudoBankRepository.insertRowToCryptoLogsTable(jdbcTemplate, userID, cryptoToBuy, CRYPTO_HISTORY_SELL_ACTION, currentTime, cryptoAmountToSell);
+      TestudoBankRepository.insertRowToCryptoLogsTable(jdbcTemplate, userID, cryptoToBuy, CRYPTO_HISTORY_SELL_ACTION,
+          currentTime, cryptoAmountToSell);
 
       updateAccountInfo(user);
 
@@ -799,12 +874,50 @@ public class MvcController {
   }
 
   /**
-   * 
+   * Applies interest rate of 1.5% APY to the customer's balance for every five
+   * deposits. This only counts for deposits that are $20 or more.
    * 
    * @param user
-   * @return "account_info" if interest applied. Otherwise, redirect to "welcome" page.
+   * @return "account_info" if interest applied. Otherwise, redirect to "welcome"
+   *         page.
    */
   public String applyInterest(@ModelAttribute("user") User user) {
+    String userID = user.getUsername();
+    double userDepositAmt = user.getAmountToDeposit();
+    int userDepositAmtInPennies = convertDollarsToPennies(userDepositAmt);
+    int numDeposits = TestudoBankRepository.getCustomerNumberOfDepositsForInterest(jdbcTemplate, userID);
+
+    // customer must deposit $20 or more
+    if (userDepositAmtInPennies < 2000) {
+      return "welcome";
+    }
+
+    // customer cannot be in overdraft or have an empty balance
+    int userOverdraftInPennies = TestudoBankRepository.getCustomerOverdraftBalanceInPennies(jdbcTemplate, userID);
+    int userBalanceInPennies = TestudoBankRepository.getCustomerCashBalanceInPennies(jdbcTemplate, userID);
+    if (userOverdraftInPennies > 0 || userBalanceInPennies == 0) {
+      return "welcome";
+    }
+
+    numDeposits += 1;
+
+    TestudoBankRepository.setCustomerNumberOfDepositsForInterest(jdbcTemplate, userID, numDeposits);
+
+    // apply interest to the balance on the fifth deposit
+    if (numDeposits % 5 == 0) {
+      int userBalanceWithInterestInPennies = (int) Math.round(userBalanceInPennies * BALANCE_INTEREST_RATE);
+      int userInterestInPennies = userBalanceWithInterestInPennies - userBalanceInPennies;
+
+      TestudoBankRepository.setCustomerCashBalance(jdbcTemplate, userID, userBalanceWithInterestInPennies);
+
+      String currentTime = SQL_DATETIME_FORMATTER.format(new java.util.Date());
+      TestudoBankRepository.insertRowToTransactionHistoryTable(jdbcTemplate, userID, currentTime,
+          TRANSACTION_HISTORY_APPLY_INTEREST_ACTION, userInterestInPennies);
+
+      TestudoBankRepository.setCustomerNumberOfDepositsForInterest(jdbcTemplate, userID, 0);
+
+      return "account_info";
+    }
 
     return "welcome";
 

--- a/src/test/java/net/testudobank/helpers/MvcControllerIntegTestHelpers.java
+++ b/src/test/java/net/testudobank/helpers/MvcControllerIntegTestHelpers.java
@@ -32,9 +32,13 @@ public class MvcControllerIntegTestHelpers {
     return dataSource;
   }
 
-  // Uses given customer details to initialize the customer in the Customers and Passwords table in the MySQL DB.
-  public static void addCustomerToDB(DatabaseDelegate dbDelegate, String ID, String password, String firstName, String lastName, int balance, int overdraftBalance, int numFraudReversals, int numInterestDeposits) throws ScriptException {
-    String insertCustomerSql = String.format("INSERT INTO Customers VALUES ('%s', '%s', '%s', %d, %d, %d, %d)", ID, firstName, lastName, balance, overdraftBalance, numFraudReversals, numInterestDeposits);
+  // Uses given customer details to initialize the customer in the Customers and
+  // Passwords table in the MySQL DB.
+  public static void addCustomerToDB(DatabaseDelegate dbDelegate, String ID, String password, String firstName,
+      String lastName, int balance, int overdraftBalance, int numFraudReversals, int numInterestDeposits)
+      throws ScriptException {
+    String insertCustomerSql = String.format("INSERT INTO Customers VALUES ('%s', '%s', '%s', %d, %d, %d, %d)", ID,
+        firstName, lastName, balance, overdraftBalance, numFraudReversals, numInterestDeposits);
     ScriptUtils.executeDatabaseScript(dbDelegate, null, insertCustomerSql);
 
     String insertCustomerPasswordSql = String.format("INSERT INTO Passwords VALUES ('%s', '%s')", ID, password);
@@ -42,75 +46,101 @@ public class MvcControllerIntegTestHelpers {
   }
 
   // Adds a customer to the MySQL DB with no overdraft balance or fraud disputes
-  public static void addCustomerToDB(DatabaseDelegate dbDelegate, String ID, String password, String firstName, String lastName, int balance, int interestDeposits) throws ScriptException {
-    addCustomerToDB(dbDelegate, ID, password, firstName, lastName, balance, 0, 0, 0);
+  public static void addCustomerToDB(DatabaseDelegate dbDelegate, String ID, String password, String firstName,
+      String lastName, int balance, int interestDeposits) throws ScriptException {
+    addCustomerToDB(dbDelegate, ID, password, firstName, lastName, balance, 0, 0, interestDeposits);
   }
 
   // Set crypto balance to specified amount
-  public static void setCryptoBalance(DatabaseDelegate dbDelegate, String userID, String cryptoName, double cryptoAmount) throws ScriptException {
-    String removeOldBalanceSql = String.format("DELETE FROM CryptoHoldings WHERE CustomerID='%s' AND CryptoName= '%s';", userID, cryptoName);
+  public static void setCryptoBalance(DatabaseDelegate dbDelegate, String userID, String cryptoName,
+      double cryptoAmount) throws ScriptException {
+    String removeOldBalanceSql = String.format("DELETE FROM CryptoHoldings WHERE CustomerID='%s' AND CryptoName= '%s';",
+        userID, cryptoName);
     ScriptUtils.executeDatabaseScript(dbDelegate, null, removeOldBalanceSql);
-    String setBalanceSql = String.format("INSERT INTO CryptoHoldings (CryptoAmount,CustomerID,CryptoName) VALUES (%f, '%s' , '%s')", cryptoAmount, userID, cryptoName);
+    String setBalanceSql = String.format(
+        "INSERT INTO CryptoHoldings (CryptoAmount,CustomerID,CryptoName) VALUES (%f, '%s' , '%s')", cryptoAmount,
+        userID, cryptoName);
     ScriptUtils.executeDatabaseScript(dbDelegate, null, setBalanceSql);
   }
 
-  // Verifies that a single transaction log in the TransactionHistory table matches the expected customerID, timestamp, action, and amount
-  public static void checkTransactionLog(Map<String,Object> transactionLog, LocalDateTime timeWhenRequestSent, String expectedCustomerID, String expectedAction, int expectedAmountInPennies) {
-    assertEquals(expectedCustomerID, (String)transactionLog.get("CustomerID"));
-    assertEquals(expectedAction, (String)transactionLog.get("Action"));
-    assertEquals(expectedAmountInPennies, (int)transactionLog.get("Amount"));
-    // verify that the timestamp for the Deposit is within a reasonable range from when the request was first sent
-    LocalDateTime transactionLogTimestamp = (LocalDateTime)transactionLog.get("Timestamp");
-    LocalDateTime transactionLogTimestampAllowedUpperBound = timeWhenRequestSent.plusSeconds(MvcControllerIntegTest.REASONABLE_TIMESTAMP_EPSILON_IN_SECONDS);
-    assertTrue(transactionLogTimestamp.compareTo(timeWhenRequestSent) >= 0 && transactionLogTimestamp.compareTo(transactionLogTimestampAllowedUpperBound) <= 0);
+  // Verifies that a single transaction log in the TransactionHistory table
+  // matches the expected customerID, timestamp, action, and amount
+  public static void checkTransactionLog(Map<String, Object> transactionLog, LocalDateTime timeWhenRequestSent,
+      String expectedCustomerID, String expectedAction, int expectedAmountInPennies) {
+    assertEquals(expectedCustomerID, (String) transactionLog.get("CustomerID"));
+    assertEquals(expectedAction, (String) transactionLog.get("Action"));
+    assertEquals(expectedAmountInPennies, (int) transactionLog.get("Amount"));
+    // verify that the timestamp for the Deposit is within a reasonable range from
+    // when the request was first sent
+    LocalDateTime transactionLogTimestamp = (LocalDateTime) transactionLog.get("Timestamp");
+    LocalDateTime transactionLogTimestampAllowedUpperBound = timeWhenRequestSent
+        .plusSeconds(MvcControllerIntegTest.REASONABLE_TIMESTAMP_EPSILON_IN_SECONDS);
+    assertTrue(transactionLogTimestamp.compareTo(timeWhenRequestSent) >= 0
+        && transactionLogTimestamp.compareTo(transactionLogTimestampAllowedUpperBound) <= 0);
     System.out.println("Timestamp stored in TransactionHistory table for the request: " + transactionLogTimestamp);
   }
 
-  // Verifies that a single overdraft repayment log in the OverdraftLogs table matches the expected customerID, timestamp, depositAmt, oldOverBalance, and newOverBalance
-  public static void checkOverdraftLog(Map<String,Object> overdraftLog, LocalDateTime timeWhenRequestSent, String expectedCustomerID, int expectedDepositAmtInPennies, int expectedOldOverBalanceInPennies, int expectedNewOverBalanceInPennies) {
-    assertEquals(expectedCustomerID, (String)overdraftLog.get("CustomerID"));
-    assertEquals(expectedDepositAmtInPennies, (int)overdraftLog.get("DepositAmt"));
-    assertEquals(expectedOldOverBalanceInPennies, (int)overdraftLog.get("OldOverBalance"));
-    assertEquals(expectedNewOverBalanceInPennies, (int)overdraftLog.get("NewOverBalance"));
-    // verify that the timestamp for the overdraft repayement is within a reasonable range from when the Deposit request was first sent
-    LocalDateTime overdraftLogTimestamp = (LocalDateTime)overdraftLog.get("Timestamp");
-    LocalDateTime overdraftLogTimestampAllowedUpperBound = timeWhenRequestSent.plusSeconds(MvcControllerIntegTest.REASONABLE_TIMESTAMP_EPSILON_IN_SECONDS);
-    assertTrue(overdraftLogTimestamp.compareTo(timeWhenRequestSent) >= 0 && overdraftLogTimestamp.compareTo(overdraftLogTimestampAllowedUpperBound) <= 0);
+  // Verifies that a single overdraft repayment log in the OverdraftLogs table
+  // matches the expected customerID, timestamp, depositAmt, oldOverBalance, and
+  // newOverBalance
+  public static void checkOverdraftLog(Map<String, Object> overdraftLog, LocalDateTime timeWhenRequestSent,
+      String expectedCustomerID, int expectedDepositAmtInPennies, int expectedOldOverBalanceInPennies,
+      int expectedNewOverBalanceInPennies) {
+    assertEquals(expectedCustomerID, (String) overdraftLog.get("CustomerID"));
+    assertEquals(expectedDepositAmtInPennies, (int) overdraftLog.get("DepositAmt"));
+    assertEquals(expectedOldOverBalanceInPennies, (int) overdraftLog.get("OldOverBalance"));
+    assertEquals(expectedNewOverBalanceInPennies, (int) overdraftLog.get("NewOverBalance"));
+    // verify that the timestamp for the overdraft repayement is within a reasonable
+    // range from when the Deposit request was first sent
+    LocalDateTime overdraftLogTimestamp = (LocalDateTime) overdraftLog.get("Timestamp");
+    LocalDateTime overdraftLogTimestampAllowedUpperBound = timeWhenRequestSent
+        .plusSeconds(MvcControllerIntegTest.REASONABLE_TIMESTAMP_EPSILON_IN_SECONDS);
+    assertTrue(overdraftLogTimestamp.compareTo(timeWhenRequestSent) >= 0
+        && overdraftLogTimestamp.compareTo(overdraftLogTimestampAllowedUpperBound) <= 0);
     System.out.println("Timestamp stored in OverdraftLogs table for the Repayment: " + overdraftLogTimestamp);
   }
 
-  // Verifies that a single crypto log in the CryptoHistory table matches the expected customerID, timestamp, action, cryptocurrency, and amount
-  public static void checkCryptoLog(Map<String,Object> cryptoLog, LocalDateTime timeWhenRequestSent, String expectedCustomerID, String expectedAction, String expectedCryptoName, double expectedCryptoAmount) {
+  // Verifies that a single crypto log in the CryptoHistory table matches the
+  // expected customerID, timestamp, action, cryptocurrency, and amount
+  public static void checkCryptoLog(Map<String, Object> cryptoLog, LocalDateTime timeWhenRequestSent,
+      String expectedCustomerID, String expectedAction, String expectedCryptoName, double expectedCryptoAmount) {
     assertEquals(expectedCustomerID, cryptoLog.get("CustomerID"));
     assertEquals(expectedAction, cryptoLog.get("Action"));
     assertEquals(expectedCryptoAmount, ((BigDecimal) cryptoLog.get("CryptoAmount")).doubleValue());
     assertEquals(expectedCryptoName, cryptoLog.get("CryptoName"));
-    // verify that the timestamp for the Deposit is within a reasonable range from when the request was first sent
-    LocalDateTime transactionLogTimestamp = (LocalDateTime)cryptoLog.get("Timestamp");
-    LocalDateTime transactionLogTimestampAllowedUpperBound = timeWhenRequestSent.plusSeconds(MvcControllerIntegTest.REASONABLE_TIMESTAMP_EPSILON_IN_SECONDS);
-    assertTrue(transactionLogTimestamp.compareTo(timeWhenRequestSent) >= 0 && transactionLogTimestamp.compareTo(transactionLogTimestampAllowedUpperBound) <= 0);
+    // verify that the timestamp for the Deposit is within a reasonable range from
+    // when the request was first sent
+    LocalDateTime transactionLogTimestamp = (LocalDateTime) cryptoLog.get("Timestamp");
+    LocalDateTime transactionLogTimestampAllowedUpperBound = timeWhenRequestSent
+        .plusSeconds(MvcControllerIntegTest.REASONABLE_TIMESTAMP_EPSILON_IN_SECONDS);
+    assertTrue(transactionLogTimestamp.compareTo(timeWhenRequestSent) >= 0
+        && transactionLogTimestamp.compareTo(transactionLogTimestampAllowedUpperBound) <= 0);
     System.out.println("Timestamp stored in CryptoHistory table for the request: " + transactionLogTimestamp);
   }
 
-  // Converts dollar amounts in frontend to penny representation in backend MySQL DB
+  // Converts dollar amounts in frontend to penny representation in backend MySQL
+  // DB
   public static int convertDollarsToPennies(double dollarAmount) {
     return (int) (dollarAmount * 100);
   }
 
-  // Applies overdraft interest rate to a dollar amount in pennies, and returns an int penny result
+  // Applies overdraft interest rate to a dollar amount in pennies, and returns an
+  // int penny result
   public static int applyOverdraftInterest(int dollarAmountInPennies) {
     return (int) (dollarAmountInPennies * MvcController.INTEREST_RATE);
   }
 
-  // Fetches current local time with no milliseconds because the MySQL DB has granularity only up to seconds (does not use milliseconds)
+  // Fetches current local time with no milliseconds because the MySQL DB has
+  // granularity only up to seconds (does not use milliseconds)
   public static LocalDateTime fetchCurrentTimeAsLocalDateTimeNoMilliseconds() {
     LocalDateTime currentTimeAsLocalDateTime = convertDateToLocalDateTime(new java.util.Date());
     currentTimeAsLocalDateTime = currentTimeAsLocalDateTime.truncatedTo(ChronoUnit.SECONDS);
     return currentTimeAsLocalDateTime;
   }
 
-  // Converts the java.util.Date object into the LocalDateTime returned by the MySQL DB
-  public static LocalDateTime convertDateToLocalDateTime(Date dateToConvert) { 
+  // Converts the java.util.Date object into the LocalDateTime returned by the
+  // MySQL DB
+  public static LocalDateTime convertDateToLocalDateTime(Date dateToConvert) {
     return dateToConvert.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime();
   }
 }

--- a/src/test/java/net/testudobank/tests/MvcControllerIntegTest.java
+++ b/src/test/java/net/testudobank/tests/MvcControllerIntegTest.java
@@ -47,14 +47,13 @@ public class MvcControllerIntegTest {
   private static String CUSTOMER2_PASSWORD = "password";
   private static String CUSTOMER2_FIRST_NAME = "Foo1";
   private static String CUSTOMER2_LAST_NAME = "Bar1";
-  
+
   // Spins up small MySQL DB in local Docker container
   @Container
   public static MySQLContainer db = new MySQLContainer<>("mysql:5.7.37")
-    .withUsername("root")
-    .withPassword("db_password")
-    .withDatabaseName("testudo_bank");
-
+      .withUsername("root")
+      .withPassword("db_password")
+      .withDatabaseName("testudo_bank");
 
   private static MvcController controller;
   private static JdbcTemplate jdbcTemplate;
@@ -72,8 +71,10 @@ public class MvcControllerIntegTest {
 
   @AfterEach
   public void clearDB() throws ScriptException {
-    // runInitScript() pulls all the String text from the SQL file and just calls executeDatabaseScript(),
-    // so it is OK to use runInitScript() again even though we aren't initializing the DB for the first time here.
+    // runInitScript() pulls all the String text from the SQL file and just calls
+    // executeDatabaseScript(),
+    // so it is OK to use runInitScript() again even though we aren't initializing
+    // the DB for the first time here.
     // runInitScript() is a poorly-named function.
     ScriptUtils.runInitScript(dbDelegate, "clearDB.sql");
   }
@@ -86,56 +87,67 @@ public class MvcControllerIntegTest {
    * and the Deposit should be logged in the TransactionHistory table.
    * 
    * Assumes that the customer's account is in the simplest state
-   * (not in overdraft, account is not frozen due to too many transaction disputes, etc.)
+   * (not in overdraft, account is not frozen due to too many transaction
+   * disputes, etc.)
    * 
    * @throws SQLException
    * @throws ScriptException
    */
   @Test
   public void testSimpleDeposit() throws SQLException, ScriptException {
-    // initialize customer1 with a balance of $123.45 (to make sure this works for non-whole dollar amounts). represented as pennies in the DB.
+    // initialize customer1 with a balance of $123.45 (to make sure this works for
+    // non-whole dollar amounts). represented as pennies in the DB.
     double CUSTOMER1_BALANCE = 123.45;
     int CUSTOMER1_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_BALANCE);
-    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, 0);
+    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME,
+        CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, 0);
 
     // Prepare Deposit Form to Deposit $12.34 to customer 1's account.
     double CUSTOMER1_AMOUNT_TO_DEPOSIT = 12.34; // user input is in dollar amount, not pennies.
     User customer1DepositFormInputs = new User();
     customer1DepositFormInputs.setUsername(CUSTOMER1_ID);
     customer1DepositFormInputs.setPassword(CUSTOMER1_PASSWORD);
-    customer1DepositFormInputs.setAmountToDeposit(CUSTOMER1_AMOUNT_TO_DEPOSIT); 
+    customer1DepositFormInputs.setAmountToDeposit(CUSTOMER1_AMOUNT_TO_DEPOSIT);
 
     // verify that there are no logs in TransactionHistory table before Deposit
     assertEquals(0, jdbcTemplate.queryForObject("SELECT COUNT(*) FROM TransactionHistory;", Integer.class));
 
-    // store timestamp of when Deposit request is sent to verify timestamps in the TransactionHistory table later
-    LocalDateTime timeWhenDepositRequestSent = MvcControllerIntegTestHelpers.fetchCurrentTimeAsLocalDateTimeNoMilliseconds();
+    // store timestamp of when Deposit request is sent to verify timestamps in the
+    // TransactionHistory table later
+    LocalDateTime timeWhenDepositRequestSent = MvcControllerIntegTestHelpers
+        .fetchCurrentTimeAsLocalDateTimeNoMilliseconds();
     System.out.println("Timestamp when Deposit Request is sent: " + timeWhenDepositRequestSent);
 
     // send request to the Deposit Form's POST handler in MvcController
     controller.submitDeposit(customer1DepositFormInputs);
 
     // fetch updated data from the DB
-    List<Map<String,Object>> customersTableData = jdbcTemplate.queryForList("SELECT * FROM Customers;");
-    List<Map<String,Object>> transactionHistoryTableData = jdbcTemplate.queryForList("SELECT * FROM TransactionHistory;");
-  
-    // verify that customer1's data is still the only data populated in Customers table
+    List<Map<String, Object>> customersTableData = jdbcTemplate.queryForList("SELECT * FROM Customers;");
+    List<Map<String, Object>> transactionHistoryTableData = jdbcTemplate
+        .queryForList("SELECT * FROM TransactionHistory;");
+
+    // verify that customer1's data is still the only data populated in Customers
+    // table
     assertEquals(1, customersTableData.size());
-    Map<String,Object> customer1Data = customersTableData.get(0);
-    assertEquals(CUSTOMER1_ID, (String)customer1Data.get("CustomerID"));
+    Map<String, Object> customer1Data = customersTableData.get(0);
+    assertEquals(CUSTOMER1_ID, (String) customer1Data.get("CustomerID"));
 
     // verify customer balance was increased by $12.34
     double CUSTOMER1_EXPECTED_FINAL_BALANCE = CUSTOMER1_BALANCE + CUSTOMER1_AMOUNT_TO_DEPOSIT;
-    double CUSTOMER1_EXPECTED_FINAL_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_EXPECTED_FINAL_BALANCE);
-    assertEquals(CUSTOMER1_EXPECTED_FINAL_BALANCE_IN_PENNIES, (int)customer1Data.get("Balance"));
+    double CUSTOMER1_EXPECTED_FINAL_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers
+        .convertDollarsToPennies(CUSTOMER1_EXPECTED_FINAL_BALANCE);
+    assertEquals(CUSTOMER1_EXPECTED_FINAL_BALANCE_IN_PENNIES, (int) customer1Data.get("Balance"));
 
     // verify that the Deposit is the only log in TransactionHistory table
     assertEquals(1, transactionHistoryTableData.size());
-    
-    // verify that the Deposit's details are accurately logged in the TransactionHistory table
-    Map<String,Object> customer1TransactionLog = transactionHistoryTableData.get(0);
-    int CUSTOMER1_AMOUNT_TO_DEPOSIT_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_AMOUNT_TO_DEPOSIT);
-    MvcControllerIntegTestHelpers.checkTransactionLog(customer1TransactionLog, timeWhenDepositRequestSent, CUSTOMER1_ID, MvcController.TRANSACTION_HISTORY_DEPOSIT_ACTION, CUSTOMER1_AMOUNT_TO_DEPOSIT_IN_PENNIES);
+
+    // verify that the Deposit's details are accurately logged in the
+    // TransactionHistory table
+    Map<String, Object> customer1TransactionLog = transactionHistoryTableData.get(0);
+    int CUSTOMER1_AMOUNT_TO_DEPOSIT_IN_PENNIES = MvcControllerIntegTestHelpers
+        .convertDollarsToPennies(CUSTOMER1_AMOUNT_TO_DEPOSIT);
+    MvcControllerIntegTestHelpers.checkTransactionLog(customer1TransactionLog, timeWhenDepositRequestSent, CUSTOMER1_ID,
+        MvcController.TRANSACTION_HISTORY_DEPOSIT_ACTION, CUSTOMER1_AMOUNT_TO_DEPOSIT_IN_PENNIES);
   }
 
   /**
@@ -145,60 +157,72 @@ public class MvcControllerIntegTest {
    * 
    * Assumes that the customer's account is in the simplest state
    * (not already in overdraft, the withdraw does not put customer in overdraft,
-   *  account is not frozen due to too many transaction disputes, etc.)
+   * account is not frozen due to too many transaction disputes, etc.)
    * 
    * @throws SQLException
    * @throws ScriptException
    */
   @Test
   public void testSimpleWithdraw() throws SQLException, ScriptException {
-    // initialize customer1 with a balance of $123.45 (to make sure this works for non-whole dollar amounts). represented as pennies in the DB.
+    // initialize customer1 with a balance of $123.45 (to make sure this works for
+    // non-whole dollar amounts). represented as pennies in the DB.
     double CUSTOMER1_BALANCE = 123.45;
     int CUSTOMER1_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_BALANCE);
-    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, 0);
+    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME,
+        CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, 0);
 
     // Prepare Withdraw Form to Withdraw $12.34 from customer 1's account.
     double CUSTOMER1_AMOUNT_TO_WITHDRAW = 12.34; // user input is in dollar amount, not pennies.
     User customer1WithdrawFormInputs = new User();
     customer1WithdrawFormInputs.setUsername(CUSTOMER1_ID);
     customer1WithdrawFormInputs.setPassword(CUSTOMER1_PASSWORD);
-    customer1WithdrawFormInputs.setAmountToWithdraw(CUSTOMER1_AMOUNT_TO_WITHDRAW); // user input is in dollar amount, not pennies.
+    customer1WithdrawFormInputs.setAmountToWithdraw(CUSTOMER1_AMOUNT_TO_WITHDRAW); // user input is in dollar amount,
+                                                                                   // not pennies.
 
     // verify that there are no logs in TransactionHistory table before Withdraw
     assertEquals(0, jdbcTemplate.queryForObject("SELECT COUNT(*) FROM TransactionHistory;", Integer.class));
 
-    // store timestamp of when Withdraw request is sent to verify timestamps in the TransactionHistory table later
-    LocalDateTime timeWhenWithdrawRequestSent = MvcControllerIntegTestHelpers.fetchCurrentTimeAsLocalDateTimeNoMilliseconds();
+    // store timestamp of when Withdraw request is sent to verify timestamps in the
+    // TransactionHistory table later
+    LocalDateTime timeWhenWithdrawRequestSent = MvcControllerIntegTestHelpers
+        .fetchCurrentTimeAsLocalDateTimeNoMilliseconds();
     System.out.println("Timestamp when Withdraw Request is sent: " + timeWhenWithdrawRequestSent);
 
     // send request to the Withdraw Form's POST handler in MvcController
     controller.submitWithdraw(customer1WithdrawFormInputs);
 
     // fetch updated data from the DB
-    List<Map<String,Object>> customersTableData = jdbcTemplate.queryForList("SELECT * FROM Customers;");
-    List<Map<String,Object>> transactionHistoryTableData = jdbcTemplate.queryForList("SELECT * FROM TransactionHistory;");
-  
-    // verify that customer1's data is still the only data populated in Customers table
+    List<Map<String, Object>> customersTableData = jdbcTemplate.queryForList("SELECT * FROM Customers;");
+    List<Map<String, Object>> transactionHistoryTableData = jdbcTemplate
+        .queryForList("SELECT * FROM TransactionHistory;");
+
+    // verify that customer1's data is still the only data populated in Customers
+    // table
     assertEquals(1, customersTableData.size());
-    Map<String,Object> customer1Data = customersTableData.get(0);
-    assertEquals(CUSTOMER1_ID, (String)customer1Data.get("CustomerID"));
+    Map<String, Object> customer1Data = customersTableData.get(0);
+    assertEquals(CUSTOMER1_ID, (String) customer1Data.get("CustomerID"));
 
     // verify customer balance was decreased by $12.34
     double CUSTOMER1_EXPECTED_FINAL_BALANCE = CUSTOMER1_BALANCE - CUSTOMER1_AMOUNT_TO_WITHDRAW;
-    double CUSTOMER1_EXPECTED_FINAL_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_EXPECTED_FINAL_BALANCE);
-    assertEquals(CUSTOMER1_EXPECTED_FINAL_BALANCE_IN_PENNIES, (int)customer1Data.get("Balance"));
+    double CUSTOMER1_EXPECTED_FINAL_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers
+        .convertDollarsToPennies(CUSTOMER1_EXPECTED_FINAL_BALANCE);
+    assertEquals(CUSTOMER1_EXPECTED_FINAL_BALANCE_IN_PENNIES, (int) customer1Data.get("Balance"));
 
     // verify that the Withdraw is the only log in TransactionHistory table
     assertEquals(1, transactionHistoryTableData.size());
 
-    // verify that the Withdraw's details are accurately logged in the TransactionHistory table
-    Map<String,Object> customer1TransactionLog = transactionHistoryTableData.get(0);
-    int CUSTOMER1_AMOUNT_TO_WITHDRAW_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_AMOUNT_TO_WITHDRAW);
-    MvcControllerIntegTestHelpers.checkTransactionLog(customer1TransactionLog, timeWhenWithdrawRequestSent, CUSTOMER1_ID, MvcController.TRANSACTION_HISTORY_WITHDRAW_ACTION, CUSTOMER1_AMOUNT_TO_WITHDRAW_IN_PENNIES);
+    // verify that the Withdraw's details are accurately logged in the
+    // TransactionHistory table
+    Map<String, Object> customer1TransactionLog = transactionHistoryTableData.get(0);
+    int CUSTOMER1_AMOUNT_TO_WITHDRAW_IN_PENNIES = MvcControllerIntegTestHelpers
+        .convertDollarsToPennies(CUSTOMER1_AMOUNT_TO_WITHDRAW);
+    MvcControllerIntegTestHelpers.checkTransactionLog(customer1TransactionLog, timeWhenWithdrawRequestSent,
+        CUSTOMER1_ID, MvcController.TRANSACTION_HISTORY_WITHDRAW_ACTION, CUSTOMER1_AMOUNT_TO_WITHDRAW_IN_PENNIES);
   }
 
   /**
-   * Verifies the case where a customer withdraws more than their available balance.
+   * Verifies the case where a customer withdraws more than their available
+   * balance.
    * The customer's main balance should be set to $0, and their Overdraft balance
    * should be the remaining withdraw amount with interest applied.
    * 
@@ -212,93 +236,120 @@ public class MvcControllerIntegTest {
    */
   @Test
   public void testWithdrawTriggersOverdraft() throws SQLException, ScriptException {
-    // initialize customer1 with a balance of $123.45 (to make sure this works for non-whole dollar amounts). represented as pennies in the DB.
+    // initialize customer1 with a balance of $123.45 (to make sure this works for
+    // non-whole dollar amounts). represented as pennies in the DB.
     double CUSTOMER1_BALANCE = 123.45;
     int CUSTOMER1_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_BALANCE);
-    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, 0);
+    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME,
+        CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, 0);
 
     // Prepare Withdraw Form to Withdraw $150 from customer 1's account.
     double CUSTOMER1_AMOUNT_TO_WITHDRAW = 150; // user input is in dollar amount, not pennies.
     User customer1WithdrawFormInputs = new User();
     customer1WithdrawFormInputs.setUsername(CUSTOMER1_ID);
     customer1WithdrawFormInputs.setPassword(CUSTOMER1_PASSWORD);
-    customer1WithdrawFormInputs.setAmountToWithdraw(CUSTOMER1_AMOUNT_TO_WITHDRAW); // user input is in dollar amount, not pennies.
+    customer1WithdrawFormInputs.setAmountToWithdraw(CUSTOMER1_AMOUNT_TO_WITHDRAW); // user input is in dollar amount,
+                                                                                   // not pennies.
 
-    // store timestamp of when Withdraw request is sent to verify timestamps in the TransactionHistory table later
-    LocalDateTime timeWhenWithdrawRequestSent = MvcControllerIntegTestHelpers.fetchCurrentTimeAsLocalDateTimeNoMilliseconds();
+    // store timestamp of when Withdraw request is sent to verify timestamps in the
+    // TransactionHistory table later
+    LocalDateTime timeWhenWithdrawRequestSent = MvcControllerIntegTestHelpers
+        .fetchCurrentTimeAsLocalDateTimeNoMilliseconds();
     System.out.println("Timestamp when Withdraw Request is sent: " + timeWhenWithdrawRequestSent);
 
     // send request to the Withdraw Form's POST handler in MvcController
     controller.submitWithdraw(customer1WithdrawFormInputs);
 
     // fetch updated customer1 data from the DB
-    List<Map<String,Object>> customersTableData = jdbcTemplate.queryForList("SELECT * FROM Customers;");
-    List<Map<String,Object>> transactionHistoryTableData = jdbcTemplate.queryForList("SELECT * FROM TransactionHistory;");
-    
+    List<Map<String, Object>> customersTableData = jdbcTemplate.queryForList("SELECT * FROM Customers;");
+    List<Map<String, Object>> transactionHistoryTableData = jdbcTemplate
+        .queryForList("SELECT * FROM TransactionHistory;");
+
     // verify that customer1's main balance is now 0
-    Map<String,Object> customer1Data = customersTableData.get(0);
-    assertEquals(0, (int)customer1Data.get("Balance"));
+    Map<String, Object> customer1Data = customersTableData.get(0);
+    assertEquals(0, (int) customer1Data.get("Balance"));
 
-    // verify that customer1's Overdraft balance is equal to the remaining withdraw amount with interest applied
-    // (convert to pennies before applying interest rate to avoid floating point roundoff errors when applying the interest rate)
-    int CUSTOMER1_ORIGINAL_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_BALANCE);
-    int CUSTOMER1_AMOUNT_TO_WITHDRAW_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_AMOUNT_TO_WITHDRAW);
-    int CUSTOMER1_EXPECTED_OVERDRAFT_BALANCE_BEFORE_INTEREST_IN_PENNIES = CUSTOMER1_AMOUNT_TO_WITHDRAW_IN_PENNIES - CUSTOMER1_ORIGINAL_BALANCE_IN_PENNIES;
-    int CUSTOMER1_EXPECTED_OVERDRAFT_BALANCE_AFTER_INTEREST_IN_PENNIES = MvcControllerIntegTestHelpers.applyOverdraftInterest(CUSTOMER1_EXPECTED_OVERDRAFT_BALANCE_BEFORE_INTEREST_IN_PENNIES);
-    System.out.println("Expected Overdraft Balance in pennies: " + CUSTOMER1_EXPECTED_OVERDRAFT_BALANCE_AFTER_INTEREST_IN_PENNIES);
-    assertEquals(CUSTOMER1_EXPECTED_OVERDRAFT_BALANCE_AFTER_INTEREST_IN_PENNIES, (int)customer1Data.get("OverdraftBalance"));
+    // verify that customer1's Overdraft balance is equal to the remaining withdraw
+    // amount with interest applied
+    // (convert to pennies before applying interest rate to avoid floating point
+    // roundoff errors when applying the interest rate)
+    int CUSTOMER1_ORIGINAL_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers
+        .convertDollarsToPennies(CUSTOMER1_BALANCE);
+    int CUSTOMER1_AMOUNT_TO_WITHDRAW_IN_PENNIES = MvcControllerIntegTestHelpers
+        .convertDollarsToPennies(CUSTOMER1_AMOUNT_TO_WITHDRAW);
+    int CUSTOMER1_EXPECTED_OVERDRAFT_BALANCE_BEFORE_INTEREST_IN_PENNIES = CUSTOMER1_AMOUNT_TO_WITHDRAW_IN_PENNIES
+        - CUSTOMER1_ORIGINAL_BALANCE_IN_PENNIES;
+    int CUSTOMER1_EXPECTED_OVERDRAFT_BALANCE_AFTER_INTEREST_IN_PENNIES = MvcControllerIntegTestHelpers
+        .applyOverdraftInterest(CUSTOMER1_EXPECTED_OVERDRAFT_BALANCE_BEFORE_INTEREST_IN_PENNIES);
+    System.out.println(
+        "Expected Overdraft Balance in pennies: " + CUSTOMER1_EXPECTED_OVERDRAFT_BALANCE_AFTER_INTEREST_IN_PENNIES);
+    assertEquals(CUSTOMER1_EXPECTED_OVERDRAFT_BALANCE_AFTER_INTEREST_IN_PENNIES,
+        (int) customer1Data.get("OverdraftBalance"));
 
-    // verify that the Withdraw's details are accurately logged in the TransactionHistory table
-    Map<String,Object> customer1TransactionLog = transactionHistoryTableData.get(0);
-    MvcControllerIntegTestHelpers.checkTransactionLog(customer1TransactionLog, timeWhenWithdrawRequestSent, CUSTOMER1_ID, MvcController.TRANSACTION_HISTORY_WITHDRAW_ACTION, CUSTOMER1_AMOUNT_TO_WITHDRAW_IN_PENNIES);
+    // verify that the Withdraw's details are accurately logged in the
+    // TransactionHistory table
+    Map<String, Object> customer1TransactionLog = transactionHistoryTableData.get(0);
+    MvcControllerIntegTestHelpers.checkTransactionLog(customer1TransactionLog, timeWhenWithdrawRequestSent,
+        CUSTOMER1_ID, MvcController.TRANSACTION_HISTORY_WITHDRAW_ACTION, CUSTOMER1_AMOUNT_TO_WITHDRAW_IN_PENNIES);
   }
 
   /**
-   * The customer will be given an initial balance of $100 and will withdraw $1099.
-   * This will test the scenario where the withdraw excess amount, which is $100 - $1099 = -$999,
-   * results in a valid overdraft balance, but once the 2% interest rate is applied, will cross the limit
-   * of $1000. 
+   * The customer will be given an initial balance of $100 and will withdraw
+   * $1099.
+   * This will test the scenario where the withdraw excess amount, which is $100 -
+   * $1099 = -$999,
+   * results in a valid overdraft balance, but once the 2% interest rate is
+   * applied, will cross the limit
+   * of $1000.
    * 
-   * This test checks to make sure that the customer's balance stays the same as before due to a failed 
+   * This test checks to make sure that the customer's balance stays the same as
+   * before due to a failed
    * withdraw request, and checks that the TransactionHistory table is empty.
    * 
    * @throws SQLException
    * @throws ScriptException
    */
   @Test
-  public void testWithdrawOverdraftLimitExceeded() throws SQLException, ScriptException { 
-    //initialize customer1 with a balance of $100. this will be represented as pennies in DB.
+  public void testWithdrawOverdraftLimitExceeded() throws SQLException, ScriptException {
+    // initialize customer1 with a balance of $100. this will be represented as
+    // pennies in DB.
     double CUSTOMER1_BALANCE = 100;
     int CUSTOMER1_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_BALANCE);
-    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, 0);
+    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME,
+        CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, 0);
 
-    //Prepare Withdraw Form to withdraw $1099 from this customer's account.
-    double CUSTOMER1_AMOUNT_TO_WITHDRAW = 1099; 
+    // Prepare Withdraw Form to withdraw $1099 from this customer's account.
+    double CUSTOMER1_AMOUNT_TO_WITHDRAW = 1099;
     User customer1WithdrawFormInputs = new User();
     customer1WithdrawFormInputs.setUsername(CUSTOMER1_ID);
     customer1WithdrawFormInputs.setPassword(CUSTOMER1_PASSWORD);
     customer1WithdrawFormInputs.setAmountToWithdraw(CUSTOMER1_AMOUNT_TO_WITHDRAW);
 
-    //Store the timestamp of the withdraw request to verify it in the TransactionHistory table later
-    LocalDateTime timeWhenWithdrawRequestSent = MvcControllerIntegTestHelpers.fetchCurrentTimeAsLocalDateTimeNoMilliseconds();
+    // Store the timestamp of the withdraw request to verify it in the
+    // TransactionHistory table later
+    LocalDateTime timeWhenWithdrawRequestSent = MvcControllerIntegTestHelpers
+        .fetchCurrentTimeAsLocalDateTimeNoMilliseconds();
     System.out.println("Timestamp when withdraw request sent: " + timeWhenWithdrawRequestSent);
 
-    //Check the response when the withdraw request is submitted. This should return the user back to the home screen due to an invalid request
+    // Check the response when the withdraw request is submitted. This should return
+    // the user back to the home screen due to an invalid request
     String responsePage = controller.submitWithdraw(customer1WithdrawFormInputs);
     assertEquals("welcome", responsePage);
 
-    //Fetch customer1's data from DB
+    // Fetch customer1's data from DB
     List<Map<String, Object>> customersTableData = jdbcTemplate.queryForList("SELECT * FROM Customers;");
 
-    //Since the request did not go through, the balance is supposed to stay the same.
+    // Since the request did not go through, the balance is supposed to stay the
+    // same.
     Map<String, Object> customer1Data = customersTableData.get(0);
-    assertEquals(CUSTOMER1_BALANCE_IN_PENNIES, (int)customer1Data.get("Balance"));
+    assertEquals(CUSTOMER1_BALANCE_IN_PENNIES, (int) customer1Data.get("Balance"));
 
-    //Checks to make sure that the overdraft balance was not increased
-    assertEquals(0, (int)customer1Data.get("OverdraftBalance"));
+    // Checks to make sure that the overdraft balance was not increased
+    assertEquals(0, (int) customer1Data.get("OverdraftBalance"));
 
-    //check that TransactionHistory table is empty
-    List<Map<String, Object>> transactionHistoryTableData = jdbcTemplate.queryForList("SELECT * FROM TransactionHistory;");
+    // check that TransactionHistory table is empty
+    List<Map<String, Object>> transactionHistoryTableData = jdbcTemplate
+        .queryForList("SELECT * FROM TransactionHistory;");
     assertTrue(transactionHistoryTableData.isEmpty());
 
   }
@@ -309,7 +360,8 @@ public class MvcControllerIntegTest {
    * in the Customers table should be set to $0, and their main Balance
    * should be set to the excess deposit amount.
    * 
-   * This Deposit should be logged in the OverdraftLogs table since it is a repayment.
+   * This Deposit should be logged in the OverdraftLogs table since it is a
+   * repayment.
    * 
    * This Deposit should still be recorded in the TransactionHistory table.
    * 
@@ -321,58 +373,73 @@ public class MvcControllerIntegTest {
    */
   @Test
   public void testDepositOverdraftClearedWithExcess() throws SQLException, ScriptException {
-    // initialize customer1 with an overdraft balance of $123.45 (to make sure this works for non-whole dollar amounts). represented as pennies in the DB.
+    // initialize customer1 with an overdraft balance of $123.45 (to make sure this
+    // works for non-whole dollar amounts). represented as pennies in the DB.
     int CUSTOMER1_MAIN_BALANCE_IN_PENNIES = 0;
     double CUSTOMER1_OVERDRAFT_BALANCE = 123.45;
-    int CUSTOMER1_OVERDRAFT_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_OVERDRAFT_BALANCE);
+    int CUSTOMER1_OVERDRAFT_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers
+        .convertDollarsToPennies(CUSTOMER1_OVERDRAFT_BALANCE);
     int CUSTOMER1_NUM_FRAUD_REVERSALS = 0;
-    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_MAIN_BALANCE_IN_PENNIES, CUSTOMER1_OVERDRAFT_BALANCE_IN_PENNIES, CUSTOMER1_NUM_FRAUD_REVERSALS, 0);
+    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME,
+        CUSTOMER1_LAST_NAME, CUSTOMER1_MAIN_BALANCE_IN_PENNIES, CUSTOMER1_OVERDRAFT_BALANCE_IN_PENNIES,
+        CUSTOMER1_NUM_FRAUD_REVERSALS, 0);
 
     // Prepare Deposit Form to Deposit $150 to customer 1's account.
     double CUSTOMER1_AMOUNT_TO_DEPOSIT = 150; // user input is in dollar amount, not pennies.
     User customer1DepositFormInputs = new User();
     customer1DepositFormInputs.setUsername(CUSTOMER1_ID);
     customer1DepositFormInputs.setPassword(CUSTOMER1_PASSWORD);
-    customer1DepositFormInputs.setAmountToDeposit(CUSTOMER1_AMOUNT_TO_DEPOSIT); 
+    customer1DepositFormInputs.setAmountToDeposit(CUSTOMER1_AMOUNT_TO_DEPOSIT);
 
-    // store timestamp of when Deposit request is sent to verify timestamps in the TransactionHistory and OverdraftLogs tables later
-    LocalDateTime timeWhenDepositRequestSent = MvcControllerIntegTestHelpers.fetchCurrentTimeAsLocalDateTimeNoMilliseconds();
+    // store timestamp of when Deposit request is sent to verify timestamps in the
+    // TransactionHistory and OverdraftLogs tables later
+    LocalDateTime timeWhenDepositRequestSent = MvcControllerIntegTestHelpers
+        .fetchCurrentTimeAsLocalDateTimeNoMilliseconds();
     System.out.println("Timestamp when Deposit Request is sent: " + timeWhenDepositRequestSent);
 
     // send request to the Deposit Form's POST handler in MvcController
     controller.submitDeposit(customer1DepositFormInputs);
 
     // fetch updated data from the DB
-    List<Map<String,Object>> customersTableData = jdbcTemplate.queryForList("SELECT * FROM Customers;");
-    List<Map<String,Object>> transactionHistoryTableData = jdbcTemplate.queryForList("SELECT * FROM TransactionHistory;");
-    List<Map<String,Object>> overdraftLogsTableData = jdbcTemplate.queryForList("SELECT * FROM OverdraftLogs;");
+    List<Map<String, Object>> customersTableData = jdbcTemplate.queryForList("SELECT * FROM Customers;");
+    List<Map<String, Object>> transactionHistoryTableData = jdbcTemplate
+        .queryForList("SELECT * FROM TransactionHistory;");
+    List<Map<String, Object>> overdraftLogsTableData = jdbcTemplate.queryForList("SELECT * FROM OverdraftLogs;");
 
     // verify that customer's overdraft balance is now $0
-    Map<String,Object> customer1Data = customersTableData.get(0);
-    assertEquals(0, (int)customer1Data.get("OverdraftBalance"));
+    Map<String, Object> customer1Data = customersTableData.get(0);
+    assertEquals(0, (int) customer1Data.get("OverdraftBalance"));
 
-    // verify that the customer's main balance is now $50 due to the excess deposit amount
-    int CUSTOMER1_AMOUNT_TO_DEPOSIT_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_AMOUNT_TO_DEPOSIT);
+    // verify that the customer's main balance is now $50 due to the excess deposit
+    // amount
+    int CUSTOMER1_AMOUNT_TO_DEPOSIT_IN_PENNIES = MvcControllerIntegTestHelpers
+        .convertDollarsToPennies(CUSTOMER1_AMOUNT_TO_DEPOSIT);
     int CUSTOMER1_ORIGINAL_OVERDRAFT_BALANCE_IN_PENNIES = CUSTOMER1_OVERDRAFT_BALANCE_IN_PENNIES;
-    int CUSTOMER1_EXPECTED_MAIN_BALANCE_IN_PENNIES = CUSTOMER1_AMOUNT_TO_DEPOSIT_IN_PENNIES - CUSTOMER1_ORIGINAL_OVERDRAFT_BALANCE_IN_PENNIES;
-    assertEquals(CUSTOMER1_EXPECTED_MAIN_BALANCE_IN_PENNIES, (int)customer1Data.get("Balance"));
+    int CUSTOMER1_EXPECTED_MAIN_BALANCE_IN_PENNIES = CUSTOMER1_AMOUNT_TO_DEPOSIT_IN_PENNIES
+        - CUSTOMER1_ORIGINAL_OVERDRAFT_BALANCE_IN_PENNIES;
+    assertEquals(CUSTOMER1_EXPECTED_MAIN_BALANCE_IN_PENNIES, (int) customer1Data.get("Balance"));
 
     // verify that the deposit is logged properly in the OverdraftLogs table
-    Map<String,Object> customer1OverdraftLog = overdraftLogsTableData.get(0);
-    MvcControllerIntegTestHelpers.checkOverdraftLog(customer1OverdraftLog, timeWhenDepositRequestSent, CUSTOMER1_ID, CUSTOMER1_AMOUNT_TO_DEPOSIT_IN_PENNIES, CUSTOMER1_ORIGINAL_OVERDRAFT_BALANCE_IN_PENNIES, 0);
+    Map<String, Object> customer1OverdraftLog = overdraftLogsTableData.get(0);
+    MvcControllerIntegTestHelpers.checkOverdraftLog(customer1OverdraftLog, timeWhenDepositRequestSent, CUSTOMER1_ID,
+        CUSTOMER1_AMOUNT_TO_DEPOSIT_IN_PENNIES, CUSTOMER1_ORIGINAL_OVERDRAFT_BALANCE_IN_PENNIES, 0);
 
-    // verify that the Deposit's details are accurately logged in the TransactionHistory table
-    Map<String,Object> customer1TransactionLog = transactionHistoryTableData.get(0);
-    MvcControllerIntegTestHelpers.checkTransactionLog(customer1TransactionLog, timeWhenDepositRequestSent, CUSTOMER1_ID, MvcController.TRANSACTION_HISTORY_DEPOSIT_ACTION, CUSTOMER1_AMOUNT_TO_DEPOSIT_IN_PENNIES);
+    // verify that the Deposit's details are accurately logged in the
+    // TransactionHistory table
+    Map<String, Object> customer1TransactionLog = transactionHistoryTableData.get(0);
+    MvcControllerIntegTestHelpers.checkTransactionLog(customer1TransactionLog, timeWhenDepositRequestSent, CUSTOMER1_ID,
+        MvcController.TRANSACTION_HISTORY_DEPOSIT_ACTION, CUSTOMER1_AMOUNT_TO_DEPOSIT_IN_PENNIES);
   }
 
   /**
    * Verifies the case where a customer is in overdraft and deposits an amount
-   * that still leaves some leftover Overdraft balance. The customer's OverdraftBalance
+   * that still leaves some leftover Overdraft balance. The customer's
+   * OverdraftBalance
    * in the Customers table should be set to $0, and their main Balance
    * should still be $0 in the MySQL DB.
    * 
-   * This Deposit should be logged in the OverdraftLogs table since it is a repayment.
+   * This Deposit should be logged in the OverdraftLogs table since it is a
+   * repayment.
    * 
    * This Deposit should still be recorded in the TransactionHistory table.
    * 
@@ -384,50 +451,63 @@ public class MvcControllerIntegTest {
    */
   @Test
   public void testDepositOverdraftNotCleared() throws SQLException, ScriptException {
-    // initialize customer1 with an overdraft balance of $123.45 (to make sure this works for non-whole dollar amounts). represented as pennies in the DB.
+    // initialize customer1 with an overdraft balance of $123.45 (to make sure this
+    // works for non-whole dollar amounts). represented as pennies in the DB.
     int CUSTOMER1_MAIN_BALANCE_IN_PENNIES = 0;
     double CUSTOMER1_OVERDRAFT_BALANCE = 123.45;
-    int CUSTOMER1_OVERDRAFT_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_OVERDRAFT_BALANCE);
+    int CUSTOMER1_OVERDRAFT_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers
+        .convertDollarsToPennies(CUSTOMER1_OVERDRAFT_BALANCE);
     int CUSTOMER1_NUM_FRAUD_REVERSALS = 0;
-    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_MAIN_BALANCE_IN_PENNIES, CUSTOMER1_OVERDRAFT_BALANCE_IN_PENNIES, CUSTOMER1_NUM_FRAUD_REVERSALS, 0);
+    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME,
+        CUSTOMER1_LAST_NAME, CUSTOMER1_MAIN_BALANCE_IN_PENNIES, CUSTOMER1_OVERDRAFT_BALANCE_IN_PENNIES,
+        CUSTOMER1_NUM_FRAUD_REVERSALS, 0);
 
     // Prepare Deposit Form to Deposit $50 to customer 1's account.
     double CUSTOMER1_AMOUNT_TO_DEPOSIT = 50; // user input is in dollar amount, not pennies.
     User customer1DepositFormInputs = new User();
     customer1DepositFormInputs.setUsername(CUSTOMER1_ID);
     customer1DepositFormInputs.setPassword(CUSTOMER1_PASSWORD);
-    customer1DepositFormInputs.setAmountToDeposit(CUSTOMER1_AMOUNT_TO_DEPOSIT); 
+    customer1DepositFormInputs.setAmountToDeposit(CUSTOMER1_AMOUNT_TO_DEPOSIT);
 
-    // store timestamp of when Deposit request is sent to verify timestamps in the TransactionHistory and OverdraftLogs tables later
-    LocalDateTime timeWhenDepositRequestSent = MvcControllerIntegTestHelpers.fetchCurrentTimeAsLocalDateTimeNoMilliseconds();
+    // store timestamp of when Deposit request is sent to verify timestamps in the
+    // TransactionHistory and OverdraftLogs tables later
+    LocalDateTime timeWhenDepositRequestSent = MvcControllerIntegTestHelpers
+        .fetchCurrentTimeAsLocalDateTimeNoMilliseconds();
     System.out.println("Timestamp when Deposit Request is sent: " + timeWhenDepositRequestSent);
 
     // send request to the Deposit Form's POST handler in MvcController
     controller.submitDeposit(customer1DepositFormInputs);
 
     // fetch updated data from the DB
-    List<Map<String,Object>> customersTableData = jdbcTemplate.queryForList("SELECT * FROM Customers;");
-    List<Map<String,Object>> transactionHistoryTableData = jdbcTemplate.queryForList("SELECT * FROM TransactionHistory;");
-    List<Map<String,Object>> overdraftLogsTableData = jdbcTemplate.queryForList("SELECT * FROM OverdraftLogs;");
+    List<Map<String, Object>> customersTableData = jdbcTemplate.queryForList("SELECT * FROM Customers;");
+    List<Map<String, Object>> transactionHistoryTableData = jdbcTemplate
+        .queryForList("SELECT * FROM TransactionHistory;");
+    List<Map<String, Object>> overdraftLogsTableData = jdbcTemplate.queryForList("SELECT * FROM OverdraftLogs;");
 
     // verify that customer's overdraft balance is now $100
-    Map<String,Object> customer1Data = customersTableData.get(0);
+    Map<String, Object> customer1Data = customersTableData.get(0);
     int CUSTOMER1_ORIGINAL_OVERDRAFT_BALANCE_IN_PENNIES = CUSTOMER1_OVERDRAFT_BALANCE_IN_PENNIES;
-    int CUSTOMER1_AMOUNT_TO_DEPOSIT_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_AMOUNT_TO_DEPOSIT);
-    int CUSTOMER1_EXPECTED_FINAL_OVERDRAFT_BALANCE_IN_PENNIES = CUSTOMER1_ORIGINAL_OVERDRAFT_BALANCE_IN_PENNIES - CUSTOMER1_AMOUNT_TO_DEPOSIT_IN_PENNIES;
-    assertEquals(CUSTOMER1_EXPECTED_FINAL_OVERDRAFT_BALANCE_IN_PENNIES, (int)customer1Data.get("OverdraftBalance"));
+    int CUSTOMER1_AMOUNT_TO_DEPOSIT_IN_PENNIES = MvcControllerIntegTestHelpers
+        .convertDollarsToPennies(CUSTOMER1_AMOUNT_TO_DEPOSIT);
+    int CUSTOMER1_EXPECTED_FINAL_OVERDRAFT_BALANCE_IN_PENNIES = CUSTOMER1_ORIGINAL_OVERDRAFT_BALANCE_IN_PENNIES
+        - CUSTOMER1_AMOUNT_TO_DEPOSIT_IN_PENNIES;
+    assertEquals(CUSTOMER1_EXPECTED_FINAL_OVERDRAFT_BALANCE_IN_PENNIES, (int) customer1Data.get("OverdraftBalance"));
 
     // verify that the customer's main balance is still $0
     int CUSTOMER1_EXPECTED_MAIN_BALANCE_IN_PENNIES = 0;
-    assertEquals(CUSTOMER1_EXPECTED_MAIN_BALANCE_IN_PENNIES, (int)customer1Data.get("Balance"));
+    assertEquals(CUSTOMER1_EXPECTED_MAIN_BALANCE_IN_PENNIES, (int) customer1Data.get("Balance"));
 
     // verify that the deposit is logged properly in the OverdraftLogs table
-    Map<String,Object> customer1OverdraftLog = overdraftLogsTableData.get(0);
-    MvcControllerIntegTestHelpers.checkOverdraftLog(customer1OverdraftLog, timeWhenDepositRequestSent, CUSTOMER1_ID, CUSTOMER1_AMOUNT_TO_DEPOSIT_IN_PENNIES, CUSTOMER1_ORIGINAL_OVERDRAFT_BALANCE_IN_PENNIES, CUSTOMER1_EXPECTED_FINAL_OVERDRAFT_BALANCE_IN_PENNIES);
+    Map<String, Object> customer1OverdraftLog = overdraftLogsTableData.get(0);
+    MvcControllerIntegTestHelpers.checkOverdraftLog(customer1OverdraftLog, timeWhenDepositRequestSent, CUSTOMER1_ID,
+        CUSTOMER1_AMOUNT_TO_DEPOSIT_IN_PENNIES, CUSTOMER1_ORIGINAL_OVERDRAFT_BALANCE_IN_PENNIES,
+        CUSTOMER1_EXPECTED_FINAL_OVERDRAFT_BALANCE_IN_PENNIES);
 
-    // verify that the Withdraw's details are accurately logged in the TransactionHistory table
-    Map<String,Object> customer1TransactionLog = transactionHistoryTableData.get(0);
-    MvcControllerIntegTestHelpers.checkTransactionLog(customer1TransactionLog, timeWhenDepositRequestSent, CUSTOMER1_ID, MvcController.TRANSACTION_HISTORY_DEPOSIT_ACTION, CUSTOMER1_AMOUNT_TO_DEPOSIT_IN_PENNIES);
+    // verify that the Withdraw's details are accurately logged in the
+    // TransactionHistory table
+    Map<String, Object> customer1TransactionLog = transactionHistoryTableData.get(0);
+    MvcControllerIntegTestHelpers.checkTransactionLog(customer1TransactionLog, timeWhenDepositRequestSent, CUSTOMER1_ID,
+        MvcController.TRANSACTION_HISTORY_DEPOSIT_ACTION, CUSTOMER1_AMOUNT_TO_DEPOSIT_IN_PENNIES);
   }
 
   /**
@@ -450,42 +530,51 @@ public class MvcControllerIntegTest {
    */
   @Test
   public void testReversalOfSimpleDeposit() throws SQLException, ScriptException, InterruptedException {
-    // initialize customer1 with a balance of $123.45 (to make sure this works for non-whole dollar amounts). represented as pennies in the DB.
+    // initialize customer1 with a balance of $123.45 (to make sure this works for
+    // non-whole dollar amounts). represented as pennies in the DB.
     // No overdraft or numFraudReversals.
     double CUSTOMER1_BALANCE = 123.45;
     int CUSTOMER1_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_BALANCE);
-    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, 0);
+    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME,
+        CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, 0);
 
-    // Prepare Deposit Form to Deposit $12.34 (to make sure this works for non-whole dollar amounts) to customer 1's account.
+    // Prepare Deposit Form to Deposit $12.34 (to make sure this works for non-whole
+    // dollar amounts) to customer 1's account.
     double CUSTOMER1_AMOUNT_TO_DEPOSIT = 12.34; // user input is in dollar amount, not pennies.
     User customer1DepositFormInputs = new User();
     customer1DepositFormInputs.setUsername(CUSTOMER1_ID);
     customer1DepositFormInputs.setPassword(CUSTOMER1_PASSWORD);
     customer1DepositFormInputs.setAmountToDeposit(CUSTOMER1_AMOUNT_TO_DEPOSIT);
 
-    // store timestamp of when Deposit request is sent to verify timestamps in the TransactionHistory table later
-    LocalDateTime timeWhenDepositRequestSent = MvcControllerIntegTestHelpers.fetchCurrentTimeAsLocalDateTimeNoMilliseconds();
+    // store timestamp of when Deposit request is sent to verify timestamps in the
+    // TransactionHistory table later
+    LocalDateTime timeWhenDepositRequestSent = MvcControllerIntegTestHelpers
+        .fetchCurrentTimeAsLocalDateTimeNoMilliseconds();
     System.out.println("Timestamp when Deposit Request is sent: " + timeWhenDepositRequestSent);
 
     // send request to the Deposit Form's POST handler in MvcController
     controller.submitDeposit(customer1DepositFormInputs);
 
     // verify customer1's balance after the deposit
-    List<Map<String,Object>> customersTableData = jdbcTemplate.queryForList("SELECT * FROM Customers;");
-    Map<String,Object> customer1Data = customersTableData.get(0);
-    double CUSTOMER1_EXPECTED_BALANCE_AFTER_DEPOSIT = CUSTOMER1_BALANCE + CUSTOMER1_AMOUNT_TO_DEPOSIT; 
-    int CUSTOMER1_EXPECTED_BALANCE_AFTER_DEPOSIT_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_EXPECTED_BALANCE_AFTER_DEPOSIT);
-    assertEquals(CUSTOMER1_EXPECTED_BALANCE_AFTER_DEPOSIT_IN_PENNIES, (int)customer1Data.get("Balance"));
+    List<Map<String, Object>> customersTableData = jdbcTemplate.queryForList("SELECT * FROM Customers;");
+    Map<String, Object> customer1Data = customersTableData.get(0);
+    double CUSTOMER1_EXPECTED_BALANCE_AFTER_DEPOSIT = CUSTOMER1_BALANCE + CUSTOMER1_AMOUNT_TO_DEPOSIT;
+    int CUSTOMER1_EXPECTED_BALANCE_AFTER_DEPOSIT_IN_PENNIES = MvcControllerIntegTestHelpers
+        .convertDollarsToPennies(CUSTOMER1_EXPECTED_BALANCE_AFTER_DEPOSIT);
+    assertEquals(CUSTOMER1_EXPECTED_BALANCE_AFTER_DEPOSIT_IN_PENNIES, (int) customer1Data.get("Balance"));
 
-    // sleep for 1 second to ensure the timestamps of Deposit and Reversal are different (and sortable) in TransactionHistory table
+    // sleep for 1 second to ensure the timestamps of Deposit and Reversal are
+    // different (and sortable) in TransactionHistory table
     Thread.sleep(1000);
 
     // Prepare Reversal Form to reverse the Deposit
     User customer1ReversalFormInputs = customer1DepositFormInputs;
     customer1ReversalFormInputs.setNumTransactionsAgo(1); // reverse the most recent transaction
 
-    // store timestamp of when Reversal request is sent to verify timestamps in the TransactionHistory table later
-    LocalDateTime timeWhenReversalRequestSent = MvcControllerIntegTestHelpers.fetchCurrentTimeAsLocalDateTimeNoMilliseconds();
+    // store timestamp of when Reversal request is sent to verify timestamps in the
+    // TransactionHistory table later
+    LocalDateTime timeWhenReversalRequestSent = MvcControllerIntegTestHelpers
+        .fetchCurrentTimeAsLocalDateTimeNoMilliseconds();
     System.out.println("Timestamp when Reversal Request is sent: " + timeWhenReversalRequestSent);
 
     // send Dispute request
@@ -497,24 +586,31 @@ public class MvcControllerIntegTest {
 
     // verify that customer1's balance is back to the original value
     int CUSTOMER1_EXPECTED_BALANCE_AFTER_REVERSAL_IN_PENNIES = CUSTOMER1_BALANCE_IN_PENNIES;
-    assertEquals(CUSTOMER1_EXPECTED_BALANCE_AFTER_REVERSAL_IN_PENNIES, (int)customer1Data.get("Balance"));
+    assertEquals(CUSTOMER1_EXPECTED_BALANCE_AFTER_REVERSAL_IN_PENNIES, (int) customer1Data.get("Balance"));
 
     // verify that customer1's numFraudReversals counter is now 1
     assertEquals(1, (int) customer1Data.get("NumFraudReversals"));
 
     // fetch transaction data from the DB in chronological order
-    // the more recent transaction should be the Reversal, and the older transaction should be the Deposit
-    List<Map<String,Object>> transactionHistoryTableData = jdbcTemplate.queryForList("SELECT * FROM TransactionHistory ORDER BY Timestamp ASC;");
-    Map<String,Object> customer1DepositTransactionLog = transactionHistoryTableData.get(0);
-    Map<String,Object> customer1ReversalTransactionLog = transactionHistoryTableData.get(1);
+    // the more recent transaction should be the Reversal, and the older transaction
+    // should be the Deposit
+    List<Map<String, Object>> transactionHistoryTableData = jdbcTemplate
+        .queryForList("SELECT * FROM TransactionHistory ORDER BY Timestamp ASC;");
+    Map<String, Object> customer1DepositTransactionLog = transactionHistoryTableData.get(0);
+    Map<String, Object> customer1ReversalTransactionLog = transactionHistoryTableData.get(1);
 
-    // verify that the Deposit's details are accurately logged in the TransactionHistory table
-    int CUSTOMER1_AMOUNT_TO_DEPOSIT_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_AMOUNT_TO_DEPOSIT);
-    MvcControllerIntegTestHelpers.checkTransactionLog(customer1DepositTransactionLog, timeWhenDepositRequestSent, CUSTOMER1_ID, MvcController.TRANSACTION_HISTORY_DEPOSIT_ACTION, CUSTOMER1_AMOUNT_TO_DEPOSIT_IN_PENNIES);
+    // verify that the Deposit's details are accurately logged in the
+    // TransactionHistory table
+    int CUSTOMER1_AMOUNT_TO_DEPOSIT_IN_PENNIES = MvcControllerIntegTestHelpers
+        .convertDollarsToPennies(CUSTOMER1_AMOUNT_TO_DEPOSIT);
+    MvcControllerIntegTestHelpers.checkTransactionLog(customer1DepositTransactionLog, timeWhenDepositRequestSent,
+        CUSTOMER1_ID, MvcController.TRANSACTION_HISTORY_DEPOSIT_ACTION, CUSTOMER1_AMOUNT_TO_DEPOSIT_IN_PENNIES);
 
-    // verify that the Reversal is accurately logged in the TransactionHistory table as a Withdraw
+    // verify that the Reversal is accurately logged in the TransactionHistory table
+    // as a Withdraw
     int CUSTOMER1_AMOUNT_TO_WITHDRAW_IN_PENNIES = CUSTOMER1_AMOUNT_TO_DEPOSIT_IN_PENNIES;
-    MvcControllerIntegTestHelpers.checkTransactionLog(customer1ReversalTransactionLog, timeWhenReversalRequestSent, CUSTOMER1_ID, MvcController.TRANSACTION_HISTORY_WITHDRAW_ACTION, CUSTOMER1_AMOUNT_TO_WITHDRAW_IN_PENNIES);
+    MvcControllerIntegTestHelpers.checkTransactionLog(customer1ReversalTransactionLog, timeWhenReversalRequestSent,
+        CUSTOMER1_ID, MvcController.TRANSACTION_HISTORY_WITHDRAW_ACTION, CUSTOMER1_AMOUNT_TO_WITHDRAW_IN_PENNIES);
   }
 
   /**
@@ -537,11 +633,13 @@ public class MvcControllerIntegTest {
    */
   @Test
   public void testReversalOfSimpleWithdraw() throws SQLException, ScriptException, InterruptedException {
-    // initialize customer1 with a balance of $123.45 (to make sure this works for non-whole dollar amounts). represented as pennies in the DB.
+    // initialize customer1 with a balance of $123.45 (to make sure this works for
+    // non-whole dollar amounts). represented as pennies in the DB.
     // No overdraft or numFraudReversals.
     double CUSTOMER1_BALANCE = 123.45;
     int CUSTOMER1_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_BALANCE);
-    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, 0);
+    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME,
+        CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, 0);
 
     // Prepare Withdraw Form to Withdraw $12.34 to customer 1's account.
     double CUSTOMER1_AMOUNT_TO_WITHDRAW = 12.34; // user input is in dollar amount, not pennies.
@@ -550,29 +648,35 @@ public class MvcControllerIntegTest {
     customer1WithdrawFormInputs.setPassword(CUSTOMER1_PASSWORD);
     customer1WithdrawFormInputs.setAmountToWithdraw(CUSTOMER1_AMOUNT_TO_WITHDRAW);
 
-    // store timestamp of when Withdraw request is sent to verify timestamps in the TransactionHistory table later
-    LocalDateTime timeWhenWithdrawRequestSent = MvcControllerIntegTestHelpers.fetchCurrentTimeAsLocalDateTimeNoMilliseconds();
+    // store timestamp of when Withdraw request is sent to verify timestamps in the
+    // TransactionHistory table later
+    LocalDateTime timeWhenWithdrawRequestSent = MvcControllerIntegTestHelpers
+        .fetchCurrentTimeAsLocalDateTimeNoMilliseconds();
     System.out.println("Timestamp when Withdraw Request is sent: " + timeWhenWithdrawRequestSent);
 
     // send request to the Withdraw Form's POST handler in MvcController
     controller.submitWithdraw(customer1WithdrawFormInputs);
 
     // verify customer1's balance after the withdraw
-    List<Map<String,Object>> customersTableData = jdbcTemplate.queryForList("SELECT * FROM Customers;");
-    Map<String,Object> customer1Data = customersTableData.get(0);
+    List<Map<String, Object>> customersTableData = jdbcTemplate.queryForList("SELECT * FROM Customers;");
+    Map<String, Object> customer1Data = customersTableData.get(0);
     double CUSTOMER1_EXPECTED_BALANCE_AFTER_WITHDRAW = CUSTOMER1_BALANCE - CUSTOMER1_AMOUNT_TO_WITHDRAW;
-    int CUSTOMER1_EXPECTED_BALANCE_AFTER_WITHDRAW_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_EXPECTED_BALANCE_AFTER_WITHDRAW);
-    assertEquals(CUSTOMER1_EXPECTED_BALANCE_AFTER_WITHDRAW_IN_PENNIES, (int)customer1Data.get("Balance"));
+    int CUSTOMER1_EXPECTED_BALANCE_AFTER_WITHDRAW_IN_PENNIES = MvcControllerIntegTestHelpers
+        .convertDollarsToPennies(CUSTOMER1_EXPECTED_BALANCE_AFTER_WITHDRAW);
+    assertEquals(CUSTOMER1_EXPECTED_BALANCE_AFTER_WITHDRAW_IN_PENNIES, (int) customer1Data.get("Balance"));
 
-    // sleep for 1 second to ensure the timestamps of Withdraw and Reversal are different (and sortable) in TransactionHistory table
+    // sleep for 1 second to ensure the timestamps of Withdraw and Reversal are
+    // different (and sortable) in TransactionHistory table
     Thread.sleep(1000);
 
     // Prepare Reversal Form to reverse the Withdraw
     User customer1ReversalFormInputs = customer1WithdrawFormInputs;
     customer1ReversalFormInputs.setNumTransactionsAgo(1); // reverse the most recent transaction
 
-    // store timestamp of when Reversal request is sent to verify timestamps in the TransactionHistory table later
-    LocalDateTime timeWhenReversalRequestSent = MvcControllerIntegTestHelpers.fetchCurrentTimeAsLocalDateTimeNoMilliseconds();
+    // store timestamp of when Reversal request is sent to verify timestamps in the
+    // TransactionHistory table later
+    LocalDateTime timeWhenReversalRequestSent = MvcControllerIntegTestHelpers
+        .fetchCurrentTimeAsLocalDateTimeNoMilliseconds();
     System.out.println("Timestamp when Reversal Request is sent: " + timeWhenReversalRequestSent);
 
     // send Dispute request
@@ -584,24 +688,31 @@ public class MvcControllerIntegTest {
 
     // verify that customer1's balance is back to the original value
     int CUSTOMER1_EXPECTED_BALANCE_AFTER_REVERSAL_IN_PENNIES = CUSTOMER1_BALANCE_IN_PENNIES;
-    assertEquals(CUSTOMER1_EXPECTED_BALANCE_AFTER_REVERSAL_IN_PENNIES, (int)customer1Data.get("Balance"));
+    assertEquals(CUSTOMER1_EXPECTED_BALANCE_AFTER_REVERSAL_IN_PENNIES, (int) customer1Data.get("Balance"));
 
     // verify that customer1's numFraudReversals counter is now 1
     assertEquals(1, (int) customer1Data.get("NumFraudReversals"));
 
     // fetch transaction data from the DB in chronological order
-    // the more recent transaction should be the Reversal, and the older transaction should be the Withdraw
-    List<Map<String,Object>> transactionHistoryTableData = jdbcTemplate.queryForList("SELECT * FROM TransactionHistory ORDER BY Timestamp ASC;");
-    Map<String,Object> customer1WithdrawTransactionLog = transactionHistoryTableData.get(0);
-    Map<String,Object> customer1ReversalTransactionLog = transactionHistoryTableData.get(1);
+    // the more recent transaction should be the Reversal, and the older transaction
+    // should be the Withdraw
+    List<Map<String, Object>> transactionHistoryTableData = jdbcTemplate
+        .queryForList("SELECT * FROM TransactionHistory ORDER BY Timestamp ASC;");
+    Map<String, Object> customer1WithdrawTransactionLog = transactionHistoryTableData.get(0);
+    Map<String, Object> customer1ReversalTransactionLog = transactionHistoryTableData.get(1);
 
-    // verify that the Withdraw's details are accurately logged in the TransactionHistory table
-    int CUSTOMER1_AMOUNT_TO_WITHDRAW_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_AMOUNT_TO_WITHDRAW);
-    MvcControllerIntegTestHelpers.checkTransactionLog(customer1WithdrawTransactionLog, timeWhenWithdrawRequestSent, CUSTOMER1_ID, MvcController.TRANSACTION_HISTORY_WITHDRAW_ACTION, CUSTOMER1_AMOUNT_TO_WITHDRAW_IN_PENNIES);
+    // verify that the Withdraw's details are accurately logged in the
+    // TransactionHistory table
+    int CUSTOMER1_AMOUNT_TO_WITHDRAW_IN_PENNIES = MvcControllerIntegTestHelpers
+        .convertDollarsToPennies(CUSTOMER1_AMOUNT_TO_WITHDRAW);
+    MvcControllerIntegTestHelpers.checkTransactionLog(customer1WithdrawTransactionLog, timeWhenWithdrawRequestSent,
+        CUSTOMER1_ID, MvcController.TRANSACTION_HISTORY_WITHDRAW_ACTION, CUSTOMER1_AMOUNT_TO_WITHDRAW_IN_PENNIES);
 
-    // verify that the Reversal is accurately logged in the TransactionHistory table as a Deposit
+    // verify that the Reversal is accurately logged in the TransactionHistory table
+    // as a Deposit
     int CUSTOMER1_AMOUNT_TO_DEPOSIT_IN_PENNIES = CUSTOMER1_AMOUNT_TO_WITHDRAW_IN_PENNIES;
-    MvcControllerIntegTestHelpers.checkTransactionLog(customer1ReversalTransactionLog, timeWhenReversalRequestSent, CUSTOMER1_ID, MvcController.TRANSACTION_HISTORY_DEPOSIT_ACTION, CUSTOMER1_AMOUNT_TO_DEPOSIT_IN_PENNIES);
+    MvcControllerIntegTestHelpers.checkTransactionLog(customer1ReversalTransactionLog, timeWhenReversalRequestSent,
+        CUSTOMER1_ID, MvcController.TRANSACTION_HISTORY_DEPOSIT_ACTION, CUSTOMER1_AMOUNT_TO_DEPOSIT_IN_PENNIES);
   }
 
   /**
@@ -609,7 +720,7 @@ public class MvcControllerIntegTest {
    * have reached the maximum allowed disputes/reversals.
    * 
    * "Frozen" means that any further deposit, withdraw,
-   * and dispute requests are ignored and the customer is 
+   * and dispute requests are ignored and the customer is
    * simply redirected to the "welcome" page.
    * 
    * The customer should still be able to view their account
@@ -625,25 +736,29 @@ public class MvcControllerIntegTest {
     int CUSTOMER1_NUM_FRAUD_REVERSALS = MvcController.MAX_DISPUTES - 1;
     // initialize with $100 main balance and $0 overdraft balance for simplicity
     double CUSTOMER1_MAIN_BALANCE = 100;
-    int CUSTOMER1_MAIN_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_MAIN_BALANCE);
+    int CUSTOMER1_MAIN_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers
+        .convertDollarsToPennies(CUSTOMER1_MAIN_BALANCE);
     int CUSTOMER1_OVERDRAFT_BALANCE_IN_PENNIES = 0;
     int CUSTOMER1_NUM_INTEREST_DEPOSITS = 0;
-    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, 
-                                                  CUSTOMER1_ID, 
-                                                  CUSTOMER1_PASSWORD, 
-                                                  CUSTOMER1_FIRST_NAME, 
-                                                  CUSTOMER1_LAST_NAME, 
-                                                  CUSTOMER1_MAIN_BALANCE_IN_PENNIES, 
-                                                  CUSTOMER1_OVERDRAFT_BALANCE_IN_PENNIES,
-                                                  CUSTOMER1_NUM_FRAUD_REVERSALS,
-                                                  CUSTOMER1_NUM_INTEREST_DEPOSITS);
+    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate,
+        CUSTOMER1_ID,
+        CUSTOMER1_PASSWORD,
+        CUSTOMER1_FIRST_NAME,
+        CUSTOMER1_LAST_NAME,
+        CUSTOMER1_MAIN_BALANCE_IN_PENNIES,
+        CUSTOMER1_OVERDRAFT_BALANCE_IN_PENNIES,
+        CUSTOMER1_NUM_FRAUD_REVERSALS,
+        CUSTOMER1_NUM_INTEREST_DEPOSITS);
 
     // Deposit $50, and then immediately dispute/reverse that deposit.
     // this will bring the customer to the MAX_DISPUTES limit, and also have a few
-    // transactions in the TransactionHistory table that we can attempt to dispute/reverse
-    // later (which we will expect to fail due to MAX_DISPUTES limit, and not due to a lack
+    // transactions in the TransactionHistory table that we can attempt to
+    // dispute/reverse
+    // later (which we will expect to fail due to MAX_DISPUTES limit, and not due to
+    // a lack
     // of transactions to reverse for the customer).
-    // The asserts for this deposit & dispute are not very rigorous as they are covered
+    // The asserts for this deposit & dispute are not very rigorous as they are
+    // covered
     // in the testReversalOfSimpleDeposit() test case.
     double CUSTOMER1_AMOUNT_TO_DEPOSIT = 50;
     User customer1DepositFormInputs = new User();
@@ -655,11 +770,12 @@ public class MvcControllerIntegTest {
     controller.submitDeposit(customer1DepositFormInputs);
 
     // verify customer1's balance after the deposit
-    List<Map<String,Object>> customersTableData = jdbcTemplate.queryForList("SELECT * FROM Customers;");
-    Map<String,Object> customer1Data = customersTableData.get(0);
-    double CUSTOMER1_EXPECTED_BALANCE_AFTER_DEPOSIT = CUSTOMER1_MAIN_BALANCE + CUSTOMER1_AMOUNT_TO_DEPOSIT; 
-    int CUSTOMER1_EXPECTED_BALANCE_AFTER_DEPOSIT_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_EXPECTED_BALANCE_AFTER_DEPOSIT);
-    assertEquals(CUSTOMER1_EXPECTED_BALANCE_AFTER_DEPOSIT_IN_PENNIES, (int)customer1Data.get("Balance"));
+    List<Map<String, Object>> customersTableData = jdbcTemplate.queryForList("SELECT * FROM Customers;");
+    Map<String, Object> customer1Data = customersTableData.get(0);
+    double CUSTOMER1_EXPECTED_BALANCE_AFTER_DEPOSIT = CUSTOMER1_MAIN_BALANCE + CUSTOMER1_AMOUNT_TO_DEPOSIT;
+    int CUSTOMER1_EXPECTED_BALANCE_AFTER_DEPOSIT_IN_PENNIES = MvcControllerIntegTestHelpers
+        .convertDollarsToPennies(CUSTOMER1_EXPECTED_BALANCE_AFTER_DEPOSIT);
+    assertEquals(CUSTOMER1_EXPECTED_BALANCE_AFTER_DEPOSIT_IN_PENNIES, (int) customer1Data.get("Balance"));
 
     // Prepare Reversal Form to reverse the Deposit
     User customer1ReversalFormInputs = customer1DepositFormInputs;
@@ -674,14 +790,15 @@ public class MvcControllerIntegTest {
 
     // verify that customer1's balance is back to the original value
     int CUSTOMER1_EXPECTED_BALANCE_AFTER_REVERSAL_IN_PENNIES = CUSTOMER1_MAIN_BALANCE_IN_PENNIES;
-    assertEquals(CUSTOMER1_EXPECTED_BALANCE_AFTER_REVERSAL_IN_PENNIES, (int)customer1Data.get("Balance"));
+    assertEquals(CUSTOMER1_EXPECTED_BALANCE_AFTER_REVERSAL_IN_PENNIES, (int) customer1Data.get("Balance"));
 
     // verify that customer1's numFraudReversals counter is now MAX_DISPUTES
-    assertEquals(MvcController.MAX_DISPUTES, (int)customer1Data.get("NumFraudReversals"));
+    assertEquals(MvcController.MAX_DISPUTES, (int) customer1Data.get("NumFraudReversals"));
 
     // verify that there are two transactions in the TransactionHistory table
     // (one for the deposit, one for the reversal of that deposit)
-    List<Map<String,Object>> transactionHistoryTableData = jdbcTemplate.queryForList("SELECT * FROM TransactionHistory;");
+    List<Map<String, Object>> transactionHistoryTableData = jdbcTemplate
+        .queryForList("SELECT * FROM TransactionHistory;");
     assertEquals(2, transactionHistoryTableData.size());
 
     //// Begin Frozen Account Checks ////
@@ -712,21 +829,24 @@ public class MvcControllerIntegTest {
     // re-fetch updated customer data from the DB
     customersTableData = jdbcTemplate.queryForList("SELECT * FROM Customers;");
     customer1Data = customersTableData.get(0);
-    assertEquals(CUSTOMER1_EXPECTED_BALANCE_AFTER_REVERSAL_IN_PENNIES, (int)customer1Data.get("Balance"));
-    assertEquals(MvcController.MAX_DISPUTES, (int)customer1Data.get("NumFraudReversals"));
+    assertEquals(CUSTOMER1_EXPECTED_BALANCE_AFTER_REVERSAL_IN_PENNIES, (int) customer1Data.get("Balance"));
+    assertEquals(MvcController.MAX_DISPUTES, (int) customer1Data.get("NumFraudReversals"));
 
     transactionHistoryTableData = jdbcTemplate.queryForList("SELECT * FROM TransactionHistory;");
     assertEquals(2, transactionHistoryTableData.size());
   }
 
   /**
-   * Verifies the transaction dispute feature on a reversal of a deposit that 
+   * Verifies the transaction dispute feature on a reversal of a deposit that
    * causes a customer to exceed the overdraft limit.
    * 
-   * The initial Deposit and Withdraw should be recorded in the TransactionHistory table.
+   * The initial Deposit and Withdraw should be recorded in the TransactionHistory
+   * table.
    * 
-   * Trying to reverse a deposit that causes the customer to go over the overdraft limit
-   * should result in the customer being directed to the welcome screen and not process 
+   * Trying to reverse a deposit that causes the customer to go over the overdraft
+   * limit
+   * should result in the customer being directed to the welcome screen and not
+   * process
    * the reversal.
    * 
    * @throws SQLException
@@ -739,7 +859,8 @@ public class MvcControllerIntegTest {
     // No overdraft or numFraudReversals.
     double CUSTOMER1_BALANCE = 0;
     int CUSTOMER1_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_BALANCE);
-    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, 0);
+    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME,
+        CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, 0);
 
     // Prepare Deposit Form to Deposit $100 to customer 1's account.
     double CUSTOMER1_AMOUNT_TO_DEPOSIT = 100; // user input is in dollar amount, not pennies.
@@ -748,15 +869,18 @@ public class MvcControllerIntegTest {
     customer1DepositFormInputs.setPassword(CUSTOMER1_PASSWORD);
     customer1DepositFormInputs.setAmountToDeposit(CUSTOMER1_AMOUNT_TO_DEPOSIT);
 
-    // store timestamp of when Deposit request is sent to verify timestamps in the TransactionHistory table later
-    LocalDateTime timeWhenDepositRequestSent = MvcControllerIntegTestHelpers.fetchCurrentTimeAsLocalDateTimeNoMilliseconds();
+    // store timestamp of when Deposit request is sent to verify timestamps in the
+    // TransactionHistory table later
+    LocalDateTime timeWhenDepositRequestSent = MvcControllerIntegTestHelpers
+        .fetchCurrentTimeAsLocalDateTimeNoMilliseconds();
     System.out.println("Timestamp when Deposit Request is sent: " + timeWhenDepositRequestSent);
 
     // send request to the Deposit Form's POST handler in MvcController
     controller.submitDeposit(customer1DepositFormInputs);
- 
-     // sleep for 1 second to ensure the timestamps of Deposit, Withdraw, and Reversal are different (and sortable) in TransactionHistory table
-     Thread.sleep(1000);
+
+    // sleep for 1 second to ensure the timestamps of Deposit, Withdraw, and
+    // Reversal are different (and sortable) in TransactionHistory table
+    Thread.sleep(1000);
 
     // Prepare Withdraw Form to Withdraw $1050 from customer 1's account.
     double CUSTOMER1_AMOUNT_TO_WITHDRAW = 1050; // user input is in dollar amount, not pennies.
@@ -765,20 +889,25 @@ public class MvcControllerIntegTest {
     customer1WithdrawFormInputs.setPassword(CUSTOMER1_PASSWORD);
     customer1WithdrawFormInputs.setAmountToWithdraw(CUSTOMER1_AMOUNT_TO_WITHDRAW);
 
-    // store timestamp of when Withdraw request is sent to verify timestamps in the TransactionHistory table later
-    LocalDateTime timeWhenWithdrawRequestSent = MvcControllerIntegTestHelpers.fetchCurrentTimeAsLocalDateTimeNoMilliseconds();
+    // store timestamp of when Withdraw request is sent to verify timestamps in the
+    // TransactionHistory table later
+    LocalDateTime timeWhenWithdrawRequestSent = MvcControllerIntegTestHelpers
+        .fetchCurrentTimeAsLocalDateTimeNoMilliseconds();
     System.out.println("Timestamp when Withdraw Request is sent: " + timeWhenWithdrawRequestSent);
 
     // send request to the Withdraw Form's POST handler in MvcController
     controller.submitWithdraw(customer1WithdrawFormInputs);
 
-    // sleep for 1 second to ensure the timestamps of Deposit, Withdraw, and Reversal are different (and sortable) in TransactionHistory table
+    // sleep for 1 second to ensure the timestamps of Deposit, Withdraw, and
+    // Reversal are different (and sortable) in TransactionHistory table
     Thread.sleep(1000);
 
     // fetch transaction data from the DB in chronological order
-    List<Map<String,Object>> transactionHistoryTableData = jdbcTemplate.queryForList("SELECT * FROM TransactionHistory ORDER BY Timestamp ASC;");
+    List<Map<String, Object>> transactionHistoryTableData = jdbcTemplate
+        .queryForList("SELECT * FROM TransactionHistory ORDER BY Timestamp ASC;");
 
-    // verify that the Deposit & Withdraw are the only logs in TransactionHistory table
+    // verify that the Deposit & Withdraw are the only logs in TransactionHistory
+    // table
     assertEquals(2, transactionHistoryTableData.size());
 
     // Prepare Reversal Form to reverse the Deposit
@@ -790,31 +919,39 @@ public class MvcControllerIntegTest {
     assertEquals("welcome", responsePage);
 
     // re-fetch transaction data from the DB in chronological order
-    // the more recent transaction should be the Withdraw, and the older transaction should be the Deposit
+    // the more recent transaction should be the Withdraw, and the older transaction
+    // should be the Deposit
     transactionHistoryTableData = jdbcTemplate.queryForList("SELECT * FROM TransactionHistory ORDER BY Timestamp ASC;");
 
-    // verify that the original Deposit & Withdraw are still the only logs in TransactionHistory table
+    // verify that the original Deposit & Withdraw are still the only logs in
+    // TransactionHistory table
     assertEquals(2, transactionHistoryTableData.size());
 
-    Map<String,Object> customer1DepositTransactionLog = transactionHistoryTableData.get(0);
-    Map<String,Object> customer1WithdrawTransactionLog = transactionHistoryTableData.get(1);
+    Map<String, Object> customer1DepositTransactionLog = transactionHistoryTableData.get(0);
+    Map<String, Object> customer1WithdrawTransactionLog = transactionHistoryTableData.get(1);
 
-    // verify that the Deposit's details are accurately logged in the TransactionHistory table
-    int CUSTOMER1_AMOUNT_TO_DEPOSIT_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_AMOUNT_TO_DEPOSIT);
-    MvcControllerIntegTestHelpers.checkTransactionLog(customer1DepositTransactionLog, timeWhenDepositRequestSent, CUSTOMER1_ID, MvcController.TRANSACTION_HISTORY_DEPOSIT_ACTION, CUSTOMER1_AMOUNT_TO_DEPOSIT_IN_PENNIES);
+    // verify that the Deposit's details are accurately logged in the
+    // TransactionHistory table
+    int CUSTOMER1_AMOUNT_TO_DEPOSIT_IN_PENNIES = MvcControllerIntegTestHelpers
+        .convertDollarsToPennies(CUSTOMER1_AMOUNT_TO_DEPOSIT);
+    MvcControllerIntegTestHelpers.checkTransactionLog(customer1DepositTransactionLog, timeWhenDepositRequestSent,
+        CUSTOMER1_ID, MvcController.TRANSACTION_HISTORY_DEPOSIT_ACTION, CUSTOMER1_AMOUNT_TO_DEPOSIT_IN_PENNIES);
 
-    // verify that the Withdraw's details are accurately logged in the TransactionHistory table
-    int CUSTOMER1_AMOUNT_TO_WITHDRAW_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_AMOUNT_TO_WITHDRAW);
-    MvcControllerIntegTestHelpers.checkTransactionLog(customer1WithdrawTransactionLog, timeWhenWithdrawRequestSent, CUSTOMER1_ID, MvcController.TRANSACTION_HISTORY_WITHDRAW_ACTION, CUSTOMER1_AMOUNT_TO_WITHDRAW_IN_PENNIES);
+    // verify that the Withdraw's details are accurately logged in the
+    // TransactionHistory table
+    int CUSTOMER1_AMOUNT_TO_WITHDRAW_IN_PENNIES = MvcControllerIntegTestHelpers
+        .convertDollarsToPennies(CUSTOMER1_AMOUNT_TO_WITHDRAW);
+    MvcControllerIntegTestHelpers.checkTransactionLog(customer1WithdrawTransactionLog, timeWhenWithdrawRequestSent,
+        CUSTOMER1_ID, MvcController.TRANSACTION_HISTORY_WITHDRAW_ACTION, CUSTOMER1_AMOUNT_TO_WITHDRAW_IN_PENNIES);
   }
 
   /**
-   * Verifies the transaction dispute feature on a reversal of a deposit that 
+   * Verifies the transaction dispute feature on a reversal of a deposit that
    * causes a customer to fall into overdraft.
    * 
    * 
-   * Reversing a deposit that causes a customer to fall into overdraft should 
-   * make the customer go into overdraft and apply the 2% interest fee on 
+   * Reversing a deposit that causes a customer to fall into overdraft should
+   * make the customer go into overdraft and apply the 2% interest fee on
    * the overdraft balance.
    * 
    * @throws SQLException
@@ -827,7 +964,8 @@ public class MvcControllerIntegTest {
     // No overdraft or numFraudReversals.
     double CUSTOMER1_BALANCE = 0;
     int CUSTOMER1_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_BALANCE);
-    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, 0);
+    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME,
+        CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, 0);
 
     // Prepare Deposit Form to Deposit $100 to customer 1's account.
     double CUSTOMER1_AMOUNT_TO_DEPOSIT = 100; // user input is in dollar amount, not pennies.
@@ -839,7 +977,8 @@ public class MvcControllerIntegTest {
     // send request to the Deposit Form's POST handler in MvcController
     controller.submitDeposit(customer1DepositFormInputs);
 
-    // sleep for 1 second to ensure the timestamps of Withdraw and Reversal are different (and sortable) in TransactionHistory table
+    // sleep for 1 second to ensure the timestamps of Withdraw and Reversal are
+    // different (and sortable) in TransactionHistory table
     Thread.sleep(1000);
 
     // Prepare Withdraw Form to Withdraw $50 from customer 1's account.
@@ -852,11 +991,12 @@ public class MvcControllerIntegTest {
     // send request to the Withdraw Form's POST handler in MvcController
     controller.submitWithdraw(customer1WithdrawFormInputs);
 
-    // sleep for 1 second to ensure the timestamps of Withdraw and Reversal are different (and sortable) in TransactionHistory table
+    // sleep for 1 second to ensure the timestamps of Withdraw and Reversal are
+    // different (and sortable) in TransactionHistory table
     Thread.sleep(1000);
 
     // fetch updated customer1 data from the DB
-    List<Map<String,Object>> customersTableData = jdbcTemplate.queryForList("SELECT * FROM Customers;");
+    List<Map<String, Object>> customersTableData = jdbcTemplate.queryForList("SELECT * FROM Customers;");
 
     // Prepare Reversal Form to reverse the Deposit
     User customer1ReversalFormInputs = customer1DepositFormInputs;
@@ -867,30 +1007,43 @@ public class MvcControllerIntegTest {
 
     // fetch updated customer1 data from the DB
     customersTableData = jdbcTemplate.queryForList("SELECT * FROM Customers;");
-     
-     // verify that customer1's main balance is now 0
-    Map<String,Object> customer1Data = customersTableData.get(0);
-    assertEquals(0, (int)customer1Data.get("Balance"));
-    
-    // verify that customer1's Overdraft balance is equal to the remaining withdraw amount with interest applied
-    // (convert to pennies before applying interest rate to avoid floating point roundoff errors when applying the interest rate)
-    int CUSTOMER1_ORIGINAL_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_BALANCE);
-    int CUSTOMER1_AMOUNT_TO_WITHDRAW_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_AMOUNT_TO_WITHDRAW);
-    int CUSTOMER1_AMOUNT_TO_DEPOSIT_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_AMOUNT_TO_DEPOSIT);
-    int CUSTOMER1_AMOUNT_TO_REVERSE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_AMOUNT_TO_DEPOSIT);
-    int CUSTOMER1_EXPECTED_OVERDRAFT_BALANCE_BEFORE_INTEREST_IN_PENNIES = CUSTOMER1_ORIGINAL_BALANCE_IN_PENNIES + CUSTOMER1_AMOUNT_TO_DEPOSIT_IN_PENNIES + CUSTOMER1_AMOUNT_TO_WITHDRAW_IN_PENNIES - CUSTOMER1_AMOUNT_TO_REVERSE_IN_PENNIES;
-    int CUSTOMER1_EXPECTED_OVERDRAFT_BALANCE_AFTER_INTEREST_IN_PENNIES = MvcControllerIntegTestHelpers.applyOverdraftInterest(CUSTOMER1_EXPECTED_OVERDRAFT_BALANCE_BEFORE_INTEREST_IN_PENNIES);
-    System.out.println("Expected Overdraft Balance in pennies: " + CUSTOMER1_EXPECTED_OVERDRAFT_BALANCE_AFTER_INTEREST_IN_PENNIES);
-    assertEquals(CUSTOMER1_EXPECTED_OVERDRAFT_BALANCE_AFTER_INTEREST_IN_PENNIES, (int)customer1Data.get("OverdraftBalance"));
+
+    // verify that customer1's main balance is now 0
+    Map<String, Object> customer1Data = customersTableData.get(0);
+    assertEquals(0, (int) customer1Data.get("Balance"));
+
+    // verify that customer1's Overdraft balance is equal to the remaining withdraw
+    // amount with interest applied
+    // (convert to pennies before applying interest rate to avoid floating point
+    // roundoff errors when applying the interest rate)
+    int CUSTOMER1_ORIGINAL_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers
+        .convertDollarsToPennies(CUSTOMER1_BALANCE);
+    int CUSTOMER1_AMOUNT_TO_WITHDRAW_IN_PENNIES = MvcControllerIntegTestHelpers
+        .convertDollarsToPennies(CUSTOMER1_AMOUNT_TO_WITHDRAW);
+    int CUSTOMER1_AMOUNT_TO_DEPOSIT_IN_PENNIES = MvcControllerIntegTestHelpers
+        .convertDollarsToPennies(CUSTOMER1_AMOUNT_TO_DEPOSIT);
+    int CUSTOMER1_AMOUNT_TO_REVERSE_IN_PENNIES = MvcControllerIntegTestHelpers
+        .convertDollarsToPennies(CUSTOMER1_AMOUNT_TO_DEPOSIT);
+    int CUSTOMER1_EXPECTED_OVERDRAFT_BALANCE_BEFORE_INTEREST_IN_PENNIES = CUSTOMER1_ORIGINAL_BALANCE_IN_PENNIES
+        + CUSTOMER1_AMOUNT_TO_DEPOSIT_IN_PENNIES + CUSTOMER1_AMOUNT_TO_WITHDRAW_IN_PENNIES
+        - CUSTOMER1_AMOUNT_TO_REVERSE_IN_PENNIES;
+    int CUSTOMER1_EXPECTED_OVERDRAFT_BALANCE_AFTER_INTEREST_IN_PENNIES = MvcControllerIntegTestHelpers
+        .applyOverdraftInterest(CUSTOMER1_EXPECTED_OVERDRAFT_BALANCE_BEFORE_INTEREST_IN_PENNIES);
+    System.out.println(
+        "Expected Overdraft Balance in pennies: " + CUSTOMER1_EXPECTED_OVERDRAFT_BALANCE_AFTER_INTEREST_IN_PENNIES);
+    assertEquals(CUSTOMER1_EXPECTED_OVERDRAFT_BALANCE_AFTER_INTEREST_IN_PENNIES,
+        (int) customer1Data.get("OverdraftBalance"));
   }
 
   /**
-   * Verifies the transaction dispute feature on a reversal of a deposit that 
+   * Verifies the transaction dispute feature on a reversal of a deposit that
    * causes a customer to fall back into overdraft
    * 
    * 
-   * Reversing a deposit that causes a customer to fall back into an overdraft balance 
-   * greater than 0 should put the customer back into the original overdraft balance. 
+   * Reversing a deposit that causes a customer to fall back into an overdraft
+   * balance
+   * greater than 0 should put the customer back into the original overdraft
+   * balance.
    * The 2% interest rate should not be re-applied.
    * 
    * @throws SQLException
@@ -906,17 +1059,16 @@ public class MvcControllerIntegTest {
     int CUSTOMER1_OVERDRAFT_BALANCE_IN_PENNIES = 50;
     int CUSTOMER1_NUM_FRAUD_REVERSALS = 0;
     int CUSTOMER1_NUM_INTEREST_DEPOSITS = 0;
-    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, 
-                                                  CUSTOMER1_ID, 
-                                                  CUSTOMER1_PASSWORD, 
-                                                  CUSTOMER1_FIRST_NAME, 
-                                                  CUSTOMER1_LAST_NAME, 
-                                                  CUSTOMER1_BALANCE_IN_PENNIES, 
-                                                  CUSTOMER1_OVERDRAFT_BALANCE_IN_PENNIES,
-                                                  CUSTOMER1_NUM_FRAUD_REVERSALS, 
-                                                  CUSTOMER1_NUM_INTEREST_DEPOSITS
-                                                  );
-    
+    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate,
+        CUSTOMER1_ID,
+        CUSTOMER1_PASSWORD,
+        CUSTOMER1_FIRST_NAME,
+        CUSTOMER1_LAST_NAME,
+        CUSTOMER1_BALANCE_IN_PENNIES,
+        CUSTOMER1_OVERDRAFT_BALANCE_IN_PENNIES,
+        CUSTOMER1_NUM_FRAUD_REVERSALS,
+        CUSTOMER1_NUM_INTEREST_DEPOSITS);
+
     // Prepare Deposit Form to Deposit $100 to customer 1's account.
     double CUSTOMER1_AMOUNT_TO_DEPOSIT = 100; // user input is in dollar amount, not pennies.
     User customer1DepositFormInputs = new User();
@@ -926,8 +1078,9 @@ public class MvcControllerIntegTest {
 
     // send request to the Deposit Form's POST handler in MvcController
     controller.submitDeposit(customer1DepositFormInputs);
- 
-    // sleep for 1 second to ensure the timestamps of Deposit, Withdraw, and Reversal are different (and sortable) in TransactionHistory table
+
+    // sleep for 1 second to ensure the timestamps of Deposit, Withdraw, and
+    // Reversal are different (and sortable) in TransactionHistory table
     Thread.sleep(1000);
 
     // Prepare Reversal Form to reverse the Deposit
@@ -938,95 +1091,112 @@ public class MvcControllerIntegTest {
     controller.submitDispute(customer1ReversalFormInputs);
 
     // fetch updated customer1 data from the DB
-     List<Map<String,Object>> customersTableData = jdbcTemplate.queryForList("SELECT * FROM Customers;");
-     customersTableData = jdbcTemplate.queryForList("SELECT * FROM Customers;");
-     Map<String,Object> customer1Data = customersTableData.get(0);
+    List<Map<String, Object>> customersTableData = jdbcTemplate.queryForList("SELECT * FROM Customers;");
+    customersTableData = jdbcTemplate.queryForList("SELECT * FROM Customers;");
+    Map<String, Object> customer1Data = customersTableData.get(0);
 
     // verfiy that overdraft balance does not apply extra 2% interest after dispute
-    assertEquals(CUSTOMER1_OVERDRAFT_BALANCE_IN_PENNIES, (int)customer1Data.get("OverdraftBalance"));
+    assertEquals(CUSTOMER1_OVERDRAFT_BALANCE_IN_PENNIES, (int) customer1Data.get("OverdraftBalance"));
   }
 
- /**
-   * This test verifies that a simple transfer of $100 from Customer1 to Customer2 will take place. Customer1's balance will be
-   * initialized to $1000, and Customer2's balance will be $500. 
+  /**
+   * This test verifies that a simple transfer of $100 from Customer1 to Customer2
+   * will take place. Customer1's balance will be
+   * initialized to $1000, and Customer2's balance will be $500.
    * 
-   * After a successful transfer, Customer1's balance should reflect a $900 balance, and Customer2's balance should be $600. 
+   * After a successful transfer, Customer1's balance should reflect a $900
+   * balance, and Customer2's balance should be $600.
    * 
    * @throws SQLException
    */
   @Test
-  public void testTransfer() throws SQLException, ScriptException { 
+  public void testTransfer() throws SQLException, ScriptException {
 
-    //Initialize customer1 with a balance of $1000. Balance will be represented as pennies in DB.
+    // Initialize customer1 with a balance of $1000. Balance will be represented as
+    // pennies in DB.
     double CUSTOMER1_BALANCE = 1000;
     int CUSTOMER1_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_BALANCE);
-    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, 0);
+    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME,
+        CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, 0);
 
-    //Initialize customer2 with a balance of $500. Balance will be represented as pennies in DB. 
+    // Initialize customer2 with a balance of $500. Balance will be represented as
+    // pennies in DB.
     double CUSTOMER2_BALANCE = 500;
     int CUSTOMER2_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER2_BALANCE);
-    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER2_ID, CUSTOMER2_PASSWORD, CUSTOMER2_FIRST_NAME, CUSTOMER2_LAST_NAME, CUSTOMER2_BALANCE_IN_PENNIES, 0);
+    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER2_ID, CUSTOMER2_PASSWORD, CUSTOMER2_FIRST_NAME,
+        CUSTOMER2_LAST_NAME, CUSTOMER2_BALANCE_IN_PENNIES, 0);
 
-    //Amount to transfer
+    // Amount to transfer
     double TRANSFER_AMOUNT = 100;
     int TRANSFER_AMOUNT_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(TRANSFER_AMOUNT);
 
-    //Initializing users for the transfer
+    // Initializing users for the transfer
     User CUSTOMER1 = new User();
     CUSTOMER1.setUsername(CUSTOMER1_ID);
     CUSTOMER1.setPassword(CUSTOMER1_PASSWORD);
     CUSTOMER1.setTransferRecipientID(CUSTOMER2_ID);
     CUSTOMER1.setAmountToTransfer(TRANSFER_AMOUNT);
-    
-    //Send the transfer request.
+
+    // Send the transfer request.
     String returnedPage = controller.submitTransfer(CUSTOMER1);
-    
-    //Fetch customer1 & customer2's data from DB
-    List<Map<String, Object>> customer1SqlResult = jdbcTemplate.queryForList(String.format("SELECT * FROM Customers WHERE CustomerID='%s';", CUSTOMER1_ID));
+
+    // Fetch customer1 & customer2's data from DB
+    List<Map<String, Object>> customer1SqlResult = jdbcTemplate
+        .queryForList(String.format("SELECT * FROM Customers WHERE CustomerID='%s';", CUSTOMER1_ID));
     Map<String, Object> customer1Data = customer1SqlResult.get(0);
 
-    List<Map<String, Object>> customer2SqlResult = jdbcTemplate.queryForList(String.format("SELECT * FROM Customers WHERE CustomerID='%s';", CUSTOMER2_ID));
+    List<Map<String, Object>> customer2SqlResult = jdbcTemplate
+        .queryForList(String.format("SELECT * FROM Customers WHERE CustomerID='%s';", CUSTOMER2_ID));
     Map<String, Object> customer2Data = customer2SqlResult.get(0);
-   
-    //Verify that customer1's balance decreased by $100. 
-    assertEquals((CUSTOMER1_BALANCE_IN_PENNIES - TRANSFER_AMOUNT_IN_PENNIES), (int)customer1Data.get("Balance"));
 
-    //Verify that customer2's balance increased by $100.
-    assertEquals((CUSTOMER2_BALANCE_IN_PENNIES + TRANSFER_AMOUNT_IN_PENNIES), (int)customer2Data.get("Balance"));
+    // Verify that customer1's balance decreased by $100.
+    assertEquals((CUSTOMER1_BALANCE_IN_PENNIES - TRANSFER_AMOUNT_IN_PENNIES), (int) customer1Data.get("Balance"));
 
-    //Check that transfer request goes through.
+    // Verify that customer2's balance increased by $100.
+    assertEquals((CUSTOMER2_BALANCE_IN_PENNIES + TRANSFER_AMOUNT_IN_PENNIES), (int) customer2Data.get("Balance"));
+
+    // Check that transfer request goes through.
     assertEquals("account_info", returnedPage);
   }
 
   /**
-   * This test is written to check the scenario where a transfer between the sender and the recipient occurs when
-   * the recipient is in overdraft. The sender will have $1000 in the bank account and will send $100. The recipient
-   * will have an overdraft balance of $101. Receiving $100 should make the sender have an updated overdraft balance of
-   * $1. 
+   * This test is written to check the scenario where a transfer between the
+   * sender and the recipient occurs when
+   * the recipient is in overdraft. The sender will have $1000 in the bank account
+   * and will send $100. The recipient
+   * will have an overdraft balance of $101. Receiving $100 should make the sender
+   * have an updated overdraft balance of
+   * $1.
    * 
    * The sender's balance should decrease by the transfer amount.
    */
   @Test
-  public void testTransferPaysOffOverdraftBalance() throws SQLException, ScriptException { 
-    
-    //Initialize customer1 with a balance of $1000. Balance will be represented as pennies in DB.
+  public void testTransferPaysOffOverdraftBalance() throws SQLException, ScriptException {
+
+    // Initialize customer1 with a balance of $1000. Balance will be represented as
+    // pennies in DB.
     double CUSTOMER1_BALANCE = 1000;
     int CUSTOMER1_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_BALANCE);
-    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, 0);
+    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME,
+        CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, 0);
 
-    //Initialize customer2 with a balance of $0 and Overdraft balance of $101. Balance will be represented as pennies in DB. 
+    // Initialize customer2 with a balance of $0 and Overdraft balance of $101.
+    // Balance will be represented as pennies in DB.
     double CUSTOMER2_BALANCE = 0;
     int CUSTOMER2_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER2_BALANCE);
     double CUSTOMER2_OVERDRAFT_BALANCE = 101.0;
-    int CUSTOMER2_OVERDRAFT_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER2_OVERDRAFT_BALANCE);
+    int CUSTOMER2_OVERDRAFT_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers
+        .convertDollarsToPennies(CUSTOMER2_OVERDRAFT_BALANCE);
     int CUSTOMER2_NUM_FRAUD_REVERSALS = 0;
-    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER2_ID, CUSTOMER2_PASSWORD, CUSTOMER2_FIRST_NAME, CUSTOMER2_LAST_NAME, CUSTOMER2_BALANCE_IN_PENNIES, CUSTOMER2_OVERDRAFT_BALANCE_IN_PENNIES, CUSTOMER2_NUM_FRAUD_REVERSALS, 0);
+    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER2_ID, CUSTOMER2_PASSWORD, CUSTOMER2_FIRST_NAME,
+        CUSTOMER2_LAST_NAME, CUSTOMER2_BALANCE_IN_PENNIES, CUSTOMER2_OVERDRAFT_BALANCE_IN_PENNIES,
+        CUSTOMER2_NUM_FRAUD_REVERSALS, 0);
 
-    //Amount to transfer
+    // Amount to transfer
     double TRANSFER_AMOUNT = 100;
     int TRANSFER_AMOUNT_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(TRANSFER_AMOUNT);
 
-    //Initializing users for the transfer
+    // Initializing users for the transfer
     User CUSTOMER1 = new User();
     CUSTOMER1.setUsername(CUSTOMER1_ID);
     CUSTOMER1.setPassword(CUSTOMER1_PASSWORD);
@@ -1034,57 +1204,68 @@ public class MvcControllerIntegTest {
     CUSTOMER1.setTransferRecipientID(CUSTOMER2_ID);
     CUSTOMER1.setAmountToTransfer(TRANSFER_AMOUNT);
 
-    //Send the transfer request.
+    // Send the transfer request.
     String returnedPage = controller.submitTransfer(CUSTOMER1);
 
-    //fetch customer1 & customer2's data from DB
-    List<Map<String,Object>> customer1SqlResult = jdbcTemplate.queryForList(String.format("SELECT * FROM Customers WHERE CustomerID='%s';", CUSTOMER1_ID));
+    // fetch customer1 & customer2's data from DB
+    List<Map<String, Object>> customer1SqlResult = jdbcTemplate
+        .queryForList(String.format("SELECT * FROM Customers WHERE CustomerID='%s';", CUSTOMER1_ID));
     Map<String, Object> customer1Data = customer1SqlResult.get(0);
 
-    List<Map<String,Object>> customer2SqlResult = jdbcTemplate.queryForList(String.format("SELECT * FROM Customers WHERE CustomerID='%s';", CUSTOMER2_ID));
+    List<Map<String, Object>> customer2SqlResult = jdbcTemplate
+        .queryForList(String.format("SELECT * FROM Customers WHERE CustomerID='%s';", CUSTOMER2_ID));
     Map<String, Object> customer2Data = customer2SqlResult.get(0);
 
-    //Verify that customer1's balance decreased by $100. 
-    assertEquals((CUSTOMER1_BALANCE_IN_PENNIES - TRANSFER_AMOUNT_IN_PENNIES), (int)customer1Data.get("Balance"));
+    // Verify that customer1's balance decreased by $100.
+    assertEquals((CUSTOMER1_BALANCE_IN_PENNIES - TRANSFER_AMOUNT_IN_PENNIES), (int) customer1Data.get("Balance"));
 
-    //Verify that customer2's overdraft balance decreased by $100.
-    assertEquals((CUSTOMER2_OVERDRAFT_BALANCE_IN_PENNIES - TRANSFER_AMOUNT_IN_PENNIES), (int)customer2Data.get("OverdraftBalance"));
+    // Verify that customer2's overdraft balance decreased by $100.
+    assertEquals((CUSTOMER2_OVERDRAFT_BALANCE_IN_PENNIES - TRANSFER_AMOUNT_IN_PENNIES),
+        (int) customer2Data.get("OverdraftBalance"));
 
-    //Check that transfer request goes through.
+    // Check that transfer request goes through.
     assertEquals("account_info", returnedPage);
-}
+  }
 
-/**
- * This test will test a scenario where the sender sends the recipient (who currently has an overdraft balance) an amount
- * that clears the recipient's overdraft balance and deposits the remainder. 
- * 
- * The sender will be initialized with $1000, and the recipient will have an overdraft balance of $100. Due to applied interest,
- * the recipient will have an overdraft balance of $102. The sender will send $150, so the recipient's balance should reflect $48
- * after the transfer.
- * 
- * @throws SQLException
- * @throws ScriptException
- */
-@Test
-public void testTransferPaysOverdraftAndDepositsRemainder() throws SQLException, ScriptException { 
+  /**
+   * This test will test a scenario where the sender sends the recipient (who
+   * currently has an overdraft balance) an amount
+   * that clears the recipient's overdraft balance and deposits the remainder.
+   * 
+   * The sender will be initialized with $1000, and the recipient will have an
+   * overdraft balance of $100. Due to applied interest,
+   * the recipient will have an overdraft balance of $102. The sender will send
+   * $150, so the recipient's balance should reflect $48
+   * after the transfer.
+   * 
+   * @throws SQLException
+   * @throws ScriptException
+   */
+  @Test
+  public void testTransferPaysOverdraftAndDepositsRemainder() throws SQLException, ScriptException {
 
-    //Initialize customer1 with a balance of $1000. Balance will be represented as pennies in DB.
+    // Initialize customer1 with a balance of $1000. Balance will be represented as
+    // pennies in DB.
     double CUSTOMER1_BALANCE = 1000;
     int CUSTOMER1_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_BALANCE);
-    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME, CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, 0);
+    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME,
+        CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, 0);
 
     double CUSTOMER2_BALANCE = 0;
     int CUSTOMER2_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER2_BALANCE);
     double CUSTOMER2_OVERDRAFT_BALANCE = 100.0;
-    int CUSTOMER2_OVERDRAFT_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER2_OVERDRAFT_BALANCE);
+    int CUSTOMER2_OVERDRAFT_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers
+        .convertDollarsToPennies(CUSTOMER2_OVERDRAFT_BALANCE);
     int CUSTOMER2_NUM_FRAUD_REVERSALS = 0;
-    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER2_ID, CUSTOMER2_PASSWORD, CUSTOMER2_FIRST_NAME, CUSTOMER2_LAST_NAME, CUSTOMER2_BALANCE_IN_PENNIES, CUSTOMER2_OVERDRAFT_BALANCE_IN_PENNIES, CUSTOMER2_NUM_FRAUD_REVERSALS, 0);
+    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER2_ID, CUSTOMER2_PASSWORD, CUSTOMER2_FIRST_NAME,
+        CUSTOMER2_LAST_NAME, CUSTOMER2_BALANCE_IN_PENNIES, CUSTOMER2_OVERDRAFT_BALANCE_IN_PENNIES,
+        CUSTOMER2_NUM_FRAUD_REVERSALS, 0);
 
-    //Transfer $150 from sender's account to recipient's account.
+    // Transfer $150 from sender's account to recipient's account.
     double TRANSFER_AMOUNT = 150;
     int TRANSFER_AMOUNT_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(TRANSFER_AMOUNT);
 
-    //Initializing users for the transfer
+    // Initializing users for the transfer
     User CUSTOMER1 = new User();
     CUSTOMER1.setUsername(CUSTOMER1_ID);
     CUSTOMER1.setPassword(CUSTOMER1_PASSWORD);
@@ -1092,27 +1273,30 @@ public void testTransferPaysOverdraftAndDepositsRemainder() throws SQLException,
     CUSTOMER1.setTransferRecipientID(CUSTOMER2_ID);
     CUSTOMER1.setAmountToTransfer(TRANSFER_AMOUNT);
 
-    //Send the transfer request.
+    // Send the transfer request.
     String returnedPage = controller.submitTransfer(CUSTOMER1);
 
-    //fetch customer1 & customer2's data from DB
-    List<Map<String,Object>> customer1SqlResult = jdbcTemplate.queryForList(String.format("SELECT * FROM Customers WHERE CustomerID='%s';", CUSTOMER1_ID));
+    // fetch customer1 & customer2's data from DB
+    List<Map<String, Object>> customer1SqlResult = jdbcTemplate
+        .queryForList(String.format("SELECT * FROM Customers WHERE CustomerID='%s';", CUSTOMER1_ID));
     Map<String, Object> customer1Data = customer1SqlResult.get(0);
 
-    List<Map<String,Object>> customer2SqlResult = jdbcTemplate.queryForList(String.format("SELECT * FROM Customers WHERE CustomerID='%s';", CUSTOMER2_ID));
+    List<Map<String, Object>> customer2SqlResult = jdbcTemplate
+        .queryForList(String.format("SELECT * FROM Customers WHERE CustomerID='%s';", CUSTOMER2_ID));
     Map<String, Object> customer2Data = customer2SqlResult.get(0);
 
-    //Verify that customer1's balance decreased by $100. 
-    assertEquals((CUSTOMER1_BALANCE_IN_PENNIES - TRANSFER_AMOUNT_IN_PENNIES), (int)customer1Data.get("Balance"));
+    // Verify that customer1's balance decreased by $100.
+    assertEquals((CUSTOMER1_BALANCE_IN_PENNIES - TRANSFER_AMOUNT_IN_PENNIES), (int) customer1Data.get("Balance"));
 
-    //Verify that customer2's overdraft balance is now $0.
-    assertEquals(0, (int)customer2Data.get("OverdraftBalance"));
+    // Verify that customer2's overdraft balance is now $0.
+    assertEquals(0, (int) customer2Data.get("OverdraftBalance"));
 
-    //Verify that customer2's balance reflects a positive amount due to a remainder being leftover after the transfer amount - overdraft balance.
+    // Verify that customer2's balance reflects a positive amount due to a remainder
+    // being leftover after the transfer amount - overdraft balance.
     int CUSTOMER2_EXPECTED_BALANCE_IN_PENNIES = TRANSFER_AMOUNT_IN_PENNIES - CUSTOMER2_OVERDRAFT_BALANCE_IN_PENNIES;
-    assertEquals(CUSTOMER2_EXPECTED_BALANCE_IN_PENNIES, (int)customer2Data.get("Balance"));
+    assertEquals(CUSTOMER2_EXPECTED_BALANCE_IN_PENNIES, (int) customer2Data.get("Balance"));
 
-    //Check that transfer request goes through.
+    // Check that transfer request goes through.
     assertEquals("account_info", returnedPage);
   }
 
@@ -1123,6 +1307,7 @@ public void testTransferPaysOverdraftAndDepositsRemainder() throws SQLException,
   enum CryptoTransactionTestType {
     BUY("Buy", "CryptoBuy"),
     SELL("Sell", "CryptoSell");
+
     final String cryptoHistoryActionName;
     final String transactionHistoryActionName;
   }
@@ -1221,9 +1406,11 @@ public void testTransferPaysOverdraftAndDepositsRemainder() throws SQLException,
     void initialize() throws ScriptException {
       int balanceInPennies = MvcControllerIntegTestHelpers.convertDollarsToPennies(initialBalanceInDollars);
       MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME,
-              CUSTOMER1_LAST_NAME, balanceInPennies, MvcControllerIntegTestHelpers.convertDollarsToPennies(initialOverdraftBalanceInDollars), 0, 0);
+          CUSTOMER1_LAST_NAME, balanceInPennies,
+          MvcControllerIntegTestHelpers.convertDollarsToPennies(initialOverdraftBalanceInDollars), 0, 0);
       for (Map.Entry<String, Double> initialBalance : initialCryptoBalance.entrySet()) {
-        MvcControllerIntegTestHelpers.setCryptoBalance(dbDelegate, CUSTOMER1_ID, initialBalance.getKey(), initialBalance.getValue());
+        MvcControllerIntegTestHelpers.setCryptoBalance(dbDelegate, CUSTOMER1_ID, initialBalance.getKey(),
+            initialBalance.getValue());
       }
     }
 
@@ -1246,12 +1433,12 @@ public void testTransferPaysOverdraftAndDepositsRemainder() throws SQLException,
       }
       user.setWhichCryptoToBuy(transaction.cryptoName);
 
-
       // Mock the price of the cryptocurrency
       Mockito.when(cryptoPriceClient.getCurrentCryptoValue(transaction.cryptoName)).thenReturn(transaction.cryptoPrice);
 
       // attempt transaction
-      LocalDateTime cryptoTransactionTime = MvcControllerIntegTestHelpers.fetchCurrentTimeAsLocalDateTimeNoMilliseconds();
+      LocalDateTime cryptoTransactionTime = MvcControllerIntegTestHelpers
+          .fetchCurrentTimeAsLocalDateTimeNoMilliseconds();
       String returnedPage;
       if (transaction.cryptoTransactionTestType == CryptoTransactionTestType.BUY) {
         user.setAmountToBuyCrypto(transaction.cryptoAmountToTransact);
@@ -1263,7 +1450,10 @@ public void testTransferPaysOverdraftAndDepositsRemainder() throws SQLException,
 
       // check the crypto balance
       try {
-        double endingCryptoBalance = jdbcTemplate.queryForObject("SELECT CryptoAmount FROM CryptoHoldings WHERE CustomerID=? AND CryptoName=?", BigDecimal.class, CUSTOMER1_ID, transaction.cryptoName).doubleValue();
+        double endingCryptoBalance = jdbcTemplate
+            .queryForObject("SELECT CryptoAmount FROM CryptoHoldings WHERE CustomerID=? AND CryptoName=?",
+                BigDecimal.class, CUSTOMER1_ID, transaction.cryptoName)
+            .doubleValue();
         assertEquals(transaction.expectedEndingCryptoBalance, endingCryptoBalance);
       } catch (EmptyResultDataAccessException e) {
         assertEquals(transaction.expectedEndingCryptoBalance, 0);
@@ -1271,46 +1461,63 @@ public void testTransferPaysOverdraftAndDepositsRemainder() throws SQLException,
 
       // check the cash balance
       assertEquals(MvcControllerIntegTestHelpers.convertDollarsToPennies(transaction.expectedEndingBalanceInDollars),
-              jdbcTemplate.queryForObject("SELECT Balance FROM Customers WHERE CustomerID=?", Integer.class, CUSTOMER1_ID));
+          jdbcTemplate.queryForObject("SELECT Balance FROM Customers WHERE CustomerID=?", Integer.class, CUSTOMER1_ID));
 
       // check the overdraft balance
-      assertEquals(MvcControllerIntegTestHelpers.convertDollarsToPennies(transaction.expectedEndingOverdraftBalanceInDollars),
-              jdbcTemplate.queryForObject("SELECT OverdraftBalance FROM Customers WHERE CustomerID=?", Integer.class, CUSTOMER1_ID));
+      assertEquals(
+          MvcControllerIntegTestHelpers.convertDollarsToPennies(transaction.expectedEndingOverdraftBalanceInDollars),
+          jdbcTemplate.queryForObject("SELECT OverdraftBalance FROM Customers WHERE CustomerID=?", Integer.class,
+              CUSTOMER1_ID));
 
       if (!transaction.shouldSucceed) {
         // verify no transaction took place
         assertEquals("welcome", returnedPage);
-        assertEquals(numTransactions, jdbcTemplate.queryForObject("SELECT COUNT(*) FROM TransactionHistory;", Integer.class));
-        assertEquals(numTransactions, jdbcTemplate.queryForObject("SELECT COUNT(*) FROM CryptoHistory;", Integer.class));
-        assertEquals(numOverdraftTransactions, jdbcTemplate.queryForObject("SELECT COUNT(*) FROM OverdraftLogs;", Integer.class));
+        assertEquals(numTransactions,
+            jdbcTemplate.queryForObject("SELECT COUNT(*) FROM TransactionHistory;", Integer.class));
+        assertEquals(numTransactions,
+            jdbcTemplate.queryForObject("SELECT COUNT(*) FROM CryptoHistory;", Integer.class));
+        assertEquals(numOverdraftTransactions,
+            jdbcTemplate.queryForObject("SELECT COUNT(*) FROM OverdraftLogs;", Integer.class));
       } else {
         assertEquals("account_info", returnedPage);
 
         // check transaction logs
-        assertEquals(numTransactions + 1, jdbcTemplate.queryForObject("SELECT COUNT(*) FROM TransactionHistory;", Integer.class));
-        List<Map<String, Object>> transactionHistoryTableData = jdbcTemplate.queryForList("SELECT * FROM TransactionHistory ORDER BY Timestamp DESC;");
+        assertEquals(numTransactions + 1,
+            jdbcTemplate.queryForObject("SELECT COUNT(*) FROM TransactionHistory;", Integer.class));
+        List<Map<String, Object>> transactionHistoryTableData = jdbcTemplate
+            .queryForList("SELECT * FROM TransactionHistory ORDER BY Timestamp DESC;");
         Map<String, Object> customer1TransactionLog = transactionHistoryTableData.get(0);
-        int expectedCryptoValueInPennies = MvcControllerIntegTestHelpers.convertDollarsToPennies(transaction.cryptoPrice * transaction.cryptoAmountToTransact);
-        MvcControllerIntegTestHelpers.checkTransactionLog(customer1TransactionLog, cryptoTransactionTime, CUSTOMER1_ID, transaction.cryptoTransactionTestType.transactionHistoryActionName, expectedCryptoValueInPennies);
+        int expectedCryptoValueInPennies = MvcControllerIntegTestHelpers
+            .convertDollarsToPennies(transaction.cryptoPrice * transaction.cryptoAmountToTransact);
+        MvcControllerIntegTestHelpers.checkTransactionLog(customer1TransactionLog, cryptoTransactionTime, CUSTOMER1_ID,
+            transaction.cryptoTransactionTestType.transactionHistoryActionName, expectedCryptoValueInPennies);
 
         // check crypto logs
-        assertEquals(numTransactions + 1, jdbcTemplate.queryForObject("SELECT COUNT(*) FROM CryptoHistory;", Integer.class));
-        List<Map<String, Object>> cryptoHistoryTableData = jdbcTemplate.queryForList("SELECT * FROM CryptoHistory ORDER BY Timestamp DESC;");
+        assertEquals(numTransactions + 1,
+            jdbcTemplate.queryForObject("SELECT COUNT(*) FROM CryptoHistory;", Integer.class));
+        List<Map<String, Object>> cryptoHistoryTableData = jdbcTemplate
+            .queryForList("SELECT * FROM CryptoHistory ORDER BY Timestamp DESC;");
         Map<String, Object> customer1CryptoLog = cryptoHistoryTableData.get(0);
-        MvcControllerIntegTestHelpers.checkCryptoLog(customer1CryptoLog, cryptoTransactionTime, CUSTOMER1_ID, transaction.cryptoTransactionTestType.cryptoHistoryActionName,
-                transaction.cryptoName, transaction.cryptoAmountToTransact);
+        MvcControllerIntegTestHelpers.checkCryptoLog(customer1CryptoLog, cryptoTransactionTime, CUSTOMER1_ID,
+            transaction.cryptoTransactionTestType.cryptoHistoryActionName,
+            transaction.cryptoName, transaction.cryptoAmountToTransact);
 
         // check overdraft logs (if applicable)
         if (transaction.overdraftTransaction) {
-          assertEquals(numOverdraftTransactions + 1, jdbcTemplate.queryForObject("SELECT COUNT(*) FROM OverdraftLogs;", Integer.class));
-          List<Map<String, Object>> overdraftLogTableData = jdbcTemplate.queryForList("SELECT * FROM OverdraftLogs ORDER BY Timestamp DESC;");
+          assertEquals(numOverdraftTransactions + 1,
+              jdbcTemplate.queryForObject("SELECT COUNT(*) FROM OverdraftLogs;", Integer.class));
+          List<Map<String, Object>> overdraftLogTableData = jdbcTemplate
+              .queryForList("SELECT * FROM OverdraftLogs ORDER BY Timestamp DESC;");
           Map<String, Object> customer1OverdraftLog = overdraftLogTableData.get(0);
-          MvcControllerIntegTestHelpers.checkOverdraftLog(customer1OverdraftLog, cryptoTransactionTime, CUSTOMER1_ID, expectedCryptoValueInPennies,
-                  MvcControllerIntegTestHelpers.convertDollarsToPennies(transaction.initialOverdraftBalanceInDollars),
-                  MvcControllerIntegTestHelpers.convertDollarsToPennies(transaction.expectedEndingOverdraftBalanceInDollars));
+          MvcControllerIntegTestHelpers.checkOverdraftLog(customer1OverdraftLog, cryptoTransactionTime, CUSTOMER1_ID,
+              expectedCryptoValueInPennies,
+              MvcControllerIntegTestHelpers.convertDollarsToPennies(transaction.initialOverdraftBalanceInDollars),
+              MvcControllerIntegTestHelpers
+                  .convertDollarsToPennies(transaction.expectedEndingOverdraftBalanceInDollars));
           numOverdraftTransactions++;
         } else {
-          assertEquals(numOverdraftTransactions, jdbcTemplate.queryForObject("SELECT COUNT(*) FROM OverdraftLogs;", Integer.class));
+          assertEquals(numOverdraftTransactions,
+              jdbcTemplate.queryForObject("SELECT COUNT(*) FROM OverdraftLogs;", Integer.class));
         }
 
         numTransactions++;
@@ -1320,48 +1527,50 @@ public void testTransferPaysOverdraftAndDepositsRemainder() throws SQLException,
   }
 
   /**
-   * Test that no crypto buy transaction occurs when the user password is incorrect
+   * Test that no crypto buy transaction occurs when the user password is
+   * incorrect
    */
   @Test
   public void testCryptoBuyInvalidPassword() throws ScriptException {
     CryptoTransactionTester cryptoTransactionTester = CryptoTransactionTester.builder()
-            .initialBalanceInDollars(1000)
-            .build();
+        .initialBalanceInDollars(1000)
+        .build();
 
     cryptoTransactionTester.initialize();
 
     CryptoTransaction cryptoTransaction = CryptoTransaction.builder()
-            .expectedEndingBalanceInDollars(1000)
-            .cryptoPrice(1000)
-            .cryptoAmountToTransact(0.1)
-            .cryptoName("ETH")
-            .validPassword(false)
-            .cryptoTransactionTestType(CryptoTransactionTestType.BUY)
-            .shouldSucceed(false)
-            .build();
+        .expectedEndingBalanceInDollars(1000)
+        .cryptoPrice(1000)
+        .cryptoAmountToTransact(0.1)
+        .cryptoName("ETH")
+        .validPassword(false)
+        .cryptoTransactionTestType(CryptoTransactionTestType.BUY)
+        .shouldSucceed(false)
+        .build();
     cryptoTransactionTester.test(cryptoTransaction);
   }
 
   /**
-   * Test that no crypto sell transaction occurs when the user password is incorrect
+   * Test that no crypto sell transaction occurs when the user password is
+   * incorrect
    */
   @Test
   public void testCryptoSellInvalidPassword() throws ScriptException {
     CryptoTransactionTester cryptoTransactionTester = CryptoTransactionTester.builder()
-            .initialBalanceInDollars(1000)
-            .build();
+        .initialBalanceInDollars(1000)
+        .build();
 
     cryptoTransactionTester.initialize();
 
     CryptoTransaction cryptoTransaction = CryptoTransaction.builder()
-            .expectedEndingBalanceInDollars(1000)
-            .cryptoPrice(1000)
-            .cryptoAmountToTransact(0.1)
-            .validPassword(false)
-            .cryptoName("ETH")
-            .cryptoTransactionTestType(CryptoTransactionTestType.SELL)
-            .shouldSucceed(false)
-            .build();
+        .expectedEndingBalanceInDollars(1000)
+        .cryptoPrice(1000)
+        .cryptoAmountToTransact(0.1)
+        .validPassword(false)
+        .cryptoName("ETH")
+        .cryptoTransactionTestType(CryptoTransactionTestType.SELL)
+        .shouldSucceed(false)
+        .build();
     cryptoTransactionTester.test(cryptoTransaction);
   }
 
@@ -1371,21 +1580,21 @@ public void testTransferPaysOverdraftAndDepositsRemainder() throws SQLException,
   @Test
   public void testCryptoBuySimple() throws ScriptException {
     CryptoTransactionTester cryptoTransactionTester = CryptoTransactionTester.builder()
-            .initialBalanceInDollars(1000)
-            .initialCryptoBalance(Collections.singletonMap("ETH", 0.0))
-            .build();
+        .initialBalanceInDollars(1000)
+        .initialCryptoBalance(Collections.singletonMap("ETH", 0.0))
+        .build();
 
     cryptoTransactionTester.initialize();
 
     CryptoTransaction cryptoTransaction = CryptoTransaction.builder()
-            .expectedEndingBalanceInDollars(900)
-            .expectedEndingCryptoBalance(0.1)
-            .cryptoPrice(1000)
-            .cryptoAmountToTransact(0.1)
-            .cryptoName("ETH")
-            .cryptoTransactionTestType(CryptoTransactionTestType.BUY)
-            .shouldSucceed(true)
-            .build();
+        .expectedEndingBalanceInDollars(900)
+        .expectedEndingCryptoBalance(0.1)
+        .cryptoPrice(1000)
+        .cryptoAmountToTransact(0.1)
+        .cryptoName("ETH")
+        .cryptoTransactionTestType(CryptoTransactionTestType.BUY)
+        .shouldSucceed(true)
+        .build();
     cryptoTransactionTester.test(cryptoTransaction);
   }
 
@@ -1395,89 +1604,92 @@ public void testTransferPaysOverdraftAndDepositsRemainder() throws SQLException,
   @Test
   public void testCryptoSellSimple() throws ScriptException {
     CryptoTransactionTester cryptoTransactionTester = CryptoTransactionTester.builder()
-            .initialBalanceInDollars(1000)
-            .initialCryptoBalance(Collections.singletonMap("ETH", 0.1))
-            .build();
+        .initialBalanceInDollars(1000)
+        .initialCryptoBalance(Collections.singletonMap("ETH", 0.1))
+        .build();
 
     cryptoTransactionTester.initialize();
 
     CryptoTransaction cryptoTransaction = CryptoTransaction.builder()
-            .expectedEndingBalanceInDollars(1100)
-            .expectedEndingCryptoBalance(0)
-            .cryptoPrice(1000)
-            .cryptoAmountToTransact(0.1)
-            .cryptoName("ETH")
-            .cryptoTransactionTestType(CryptoTransactionTestType.SELL)
-            .shouldSucceed(true)
-            .build();
+        .expectedEndingBalanceInDollars(1100)
+        .expectedEndingCryptoBalance(0)
+        .cryptoPrice(1000)
+        .cryptoAmountToTransact(0.1)
+        .cryptoName("ETH")
+        .cryptoTransactionTestType(CryptoTransactionTestType.SELL)
+        .shouldSucceed(true)
+        .build();
     cryptoTransactionTester.test(cryptoTransaction);
   }
 
   /**
-   * Test buying of cryptocurrency with an insufficient balance does not invoke a transaction
+   * Test buying of cryptocurrency with an insufficient balance does not invoke a
+   * transaction
    */
   @Test
   public void testCryptoBuyInsufficientBalance() throws ScriptException {
     CryptoTransactionTester cryptoTransactionTester = CryptoTransactionTester.builder()
-            .initialBalanceInDollars(1000)
-            .build();
+        .initialBalanceInDollars(1000)
+        .build();
 
     cryptoTransactionTester.initialize();
 
     CryptoTransaction cryptoTransaction = CryptoTransaction.builder()
-            .expectedEndingBalanceInDollars(1000)
-            .cryptoPrice(1000)
-            .cryptoAmountToTransact(10)
-            .cryptoName("ETH")
-            .cryptoTransactionTestType(CryptoTransactionTestType.BUY)
-            .shouldSucceed(false)
-            .build();
+        .expectedEndingBalanceInDollars(1000)
+        .cryptoPrice(1000)
+        .cryptoAmountToTransact(10)
+        .cryptoName("ETH")
+        .cryptoTransactionTestType(CryptoTransactionTestType.BUY)
+        .shouldSucceed(false)
+        .build();
     cryptoTransactionTester.test(cryptoTransaction);
   }
 
   /**
-   * Test that buying a negative amount of cryptocurrency does not invoke a transaction
+   * Test that buying a negative amount of cryptocurrency does not invoke a
+   * transaction
    */
   @Test
   public void testCryptoBuyNegativeAmount() throws ScriptException {
     CryptoTransactionTester cryptoTransactionTester = CryptoTransactionTester.builder()
-            .initialBalanceInDollars(1000)
-            .build();
+        .initialBalanceInDollars(1000)
+        .build();
 
     cryptoTransactionTester.initialize();
 
     CryptoTransaction cryptoTransaction = CryptoTransaction.builder()
-            .expectedEndingBalanceInDollars(1000)
-            .cryptoPrice(1000)
-            .cryptoAmountToTransact(-0.1)
-            .cryptoName("ETH")
-            .cryptoTransactionTestType(CryptoTransactionTestType.BUY)
-            .shouldSucceed(false)
-            .build();
+        .expectedEndingBalanceInDollars(1000)
+        .cryptoPrice(1000)
+        .cryptoAmountToTransact(-0.1)
+        .cryptoName("ETH")
+        .cryptoTransactionTestType(CryptoTransactionTestType.BUY)
+        .shouldSucceed(false)
+        .build();
     cryptoTransactionTester.test(cryptoTransaction);
   }
 
   /**
-   * Test that selling a negative amount of cryptocurrency does not invoke a transaction
+   * Test that selling a negative amount of cryptocurrency does not invoke a
+   * transaction
    */
   @Test
   public void testCryptoSellNegativeAmount() throws ScriptException {
     CryptoTransactionTester cryptoTransactionTester = CryptoTransactionTester.builder()
-            .initialBalanceInDollars(1000)
-            .initialCryptoBalance(Collections.singletonMap("ETH", 0.1))
-            .build();
+        .initialBalanceInDollars(1000)
+        .initialCryptoBalance(Collections.singletonMap("ETH", 0.1))
+        .build();
 
     cryptoTransactionTester.initialize();
 
     CryptoTransaction cryptoTransaction = CryptoTransaction.builder()
-            .expectedEndingBalanceInDollars(1000)
-            .expectedEndingCryptoBalance(0.1)
-            .cryptoPrice(1000)
-            .cryptoAmountToTransact(-0.1)
-            .cryptoName("ETH")
-            .cryptoTransactionTestType(CryptoTransactionTestType.SELL)
-            .shouldSucceed(false)
-            .build();
+        .expectedEndingBalanceInDollars(1000)
+        .expectedEndingCryptoBalance(0.1)
+        .cryptoPrice(1000)
+        .cryptoAmountToTransact(-0.1)
+        .cryptoName("ETH")
+        .cryptoTransactionTestType(CryptoTransactionTestType.SELL)
+        .shouldSucceed(false)
+        .build();
     cryptoTransactionTester.test(cryptoTransaction);
   }
 
@@ -1487,22 +1699,22 @@ public void testTransferPaysOverdraftAndDepositsRemainder() throws SQLException,
   @Test
   public void testCryptoBuyOverdraft() throws ScriptException {
     CryptoTransactionTester cryptoTransactionTester = CryptoTransactionTester.builder()
-            .initialBalanceInDollars(1000)
-            .initialOverdraftBalanceInDollars(100)
-            .build();
+        .initialBalanceInDollars(1000)
+        .initialOverdraftBalanceInDollars(100)
+        .build();
 
     cryptoTransactionTester.initialize();
 
     CryptoTransaction cryptoTransaction = CryptoTransaction.builder()
-            .expectedEndingBalanceInDollars(1000)
-            .expectedEndingOverdraftBalanceInDollars(100)
-            .cryptoPrice(1000)
-            .cryptoAmountToTransact(0.1)
-            .cryptoName("ETH")
-            .cryptoTransactionTestType(CryptoTransactionTestType.BUY)
-            .overdraftTransaction(true)
-            .shouldSucceed(false)
-            .build();
+        .expectedEndingBalanceInDollars(1000)
+        .expectedEndingOverdraftBalanceInDollars(100)
+        .cryptoPrice(1000)
+        .cryptoAmountToTransact(0.1)
+        .cryptoName("ETH")
+        .cryptoTransactionTestType(CryptoTransactionTestType.BUY)
+        .overdraftTransaction(true)
+        .shouldSucceed(false)
+        .build();
     cryptoTransactionTester.test(cryptoTransaction);
   }
 
@@ -1512,74 +1724,225 @@ public void testTransferPaysOverdraftAndDepositsRemainder() throws SQLException,
   @Test
   public void testCryptoSellOverdraft() throws ScriptException {
     CryptoTransactionTester cryptoTransactionTester = CryptoTransactionTester.builder()
-            .initialBalanceInDollars(1000)
-            .initialOverdraftBalanceInDollars(50)
-            .initialCryptoBalance(Collections.singletonMap("ETH", 0.15))
-            .build();
+        .initialBalanceInDollars(1000)
+        .initialOverdraftBalanceInDollars(50)
+        .initialCryptoBalance(Collections.singletonMap("ETH", 0.15))
+        .build();
 
     cryptoTransactionTester.initialize();
 
     CryptoTransaction cryptoTransaction = CryptoTransaction.builder()
-            .initialOverdraftBalanceInDollars(50)
-            .expectedEndingBalanceInDollars(1050)
-            .expectedEndingCryptoBalance(0.05)
-            .expectedEndingOverdraftBalanceInDollars(0)
-            .cryptoPrice(1000)
-            .cryptoAmountToTransact(0.1)
-            .cryptoName("ETH")
-            .cryptoTransactionTestType(CryptoTransactionTestType.SELL)
-            .overdraftTransaction(true)
-            .shouldSucceed(true)
-            .build();
+        .initialOverdraftBalanceInDollars(50)
+        .expectedEndingBalanceInDollars(1050)
+        .expectedEndingCryptoBalance(0.05)
+        .expectedEndingOverdraftBalanceInDollars(0)
+        .cryptoPrice(1000)
+        .cryptoAmountToTransact(0.1)
+        .cryptoName("ETH")
+        .cryptoTransactionTestType(CryptoTransactionTestType.SELL)
+        .overdraftTransaction(true)
+        .shouldSucceed(true)
+        .build();
     cryptoTransactionTester.test(cryptoTransaction);
   }
 
   /**
-   * Test that no buy transaction occurs when the cryptocurrency price cannot be obtained
+   * Test that no buy transaction occurs when the cryptocurrency price cannot be
+   * obtained
    */
   @Test
   public void testCryptoBuyInvalidPrice() throws ScriptException {
     CryptoTransactionTester cryptoTransactionTester = CryptoTransactionTester.builder()
-            .initialBalanceInDollars(1000)
-            .initialCryptoBalance(Collections.singletonMap("ETH", 0.0))
-            .build();
+        .initialBalanceInDollars(1000)
+        .initialCryptoBalance(Collections.singletonMap("ETH", 0.0))
+        .build();
 
     cryptoTransactionTester.initialize();
 
     CryptoTransaction cryptoTransaction = CryptoTransaction.builder()
-            .expectedEndingBalanceInDollars(1000)
-            .expectedEndingCryptoBalance(0)
-            .cryptoPrice(-1)
-            .cryptoAmountToTransact(0.1)
-            .cryptoName("ETH")
-            .cryptoTransactionTestType(CryptoTransactionTestType.BUY)
-            .shouldSucceed(false)
-            .build();
+        .expectedEndingBalanceInDollars(1000)
+        .expectedEndingCryptoBalance(0)
+        .cryptoPrice(-1)
+        .cryptoAmountToTransact(0.1)
+        .cryptoName("ETH")
+        .cryptoTransactionTestType(CryptoTransactionTestType.BUY)
+        .shouldSucceed(false)
+        .build();
     cryptoTransactionTester.test(cryptoTransaction);
   }
 
   /**
-   * Test that no sell transaction occurs when the cryptocurrency price cannot be obtained
+   * Test that no sell transaction occurs when the cryptocurrency price cannot be
+   * obtained
    */
   @Test
   public void testCryptoSellInvalidPrice() throws ScriptException {
     CryptoTransactionTester cryptoTransactionTester = CryptoTransactionTester.builder()
-            .initialBalanceInDollars(1000)
-            .initialCryptoBalance(Collections.singletonMap("ETH", 0.1))
-            .build();
+        .initialBalanceInDollars(1000)
+        .initialCryptoBalance(Collections.singletonMap("ETH", 0.1))
+        .build();
 
     cryptoTransactionTester.initialize();
 
     CryptoTransaction cryptoTransaction = CryptoTransaction.builder()
-            .expectedEndingBalanceInDollars(1000)
-            .expectedEndingCryptoBalance(0.1)
-            .cryptoPrice(-1)
-            .cryptoAmountToTransact(0.1)
-            .cryptoName("ETH")
-            .cryptoTransactionTestType(CryptoTransactionTestType.SELL)
-            .shouldSucceed(false)
-            .build();
+        .expectedEndingBalanceInDollars(1000)
+        .expectedEndingCryptoBalance(0.1)
+        .cryptoPrice(-1)
+        .cryptoAmountToTransact(0.1)
+        .cryptoName("ETH")
+        .cryptoTransactionTestType(CryptoTransactionTestType.SELL)
+        .shouldSucceed(false)
+        .build();
     cryptoTransactionTester.test(cryptoTransaction);
+  }
+
+  /**
+   * Verifies the simplest apply interest case.
+   * The customer's Balance in the Customers table should be increased,
+   * and the Deposit and ApplyInterest should be logged in the TransactionHistory
+   * table.
+   * 
+   * Assumes that the customer's account is in the simplest state
+   * (not in overdraft, account is not frozen due to too many transaction
+   * disputes, etc.)
+   * 
+   * @throws SQLException
+   * @throws ScriptException
+   */
+  @Test
+  public void testSimpleApplyInterest() throws SQLException, ScriptException {
+    // Initialize customer1 with a balance of $1000. Balance will be represented
+    // as pennies in DB.
+    double CUSTOMER1_BALANCE = 1000;
+    int CUSTOMER1_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_BALANCE);
+    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME,
+        CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, 4);
+
+    // Prepare Deposit Form to Deposit money to customer 1's account. user input is
+    // in dollar amount, not pennies.
+    User customer1DepositFormInputs = new User();
+    customer1DepositFormInputs.setUsername(CUSTOMER1_ID);
+    customer1DepositFormInputs.setPassword(CUSTOMER1_PASSWORD);
+    double CUSTOMER1_AMOUNT_TO_DEPOSIT = 20.00;
+    double CUSTOMER1_INTEREST = 15.30;
+
+    // send a request to the Deposit Form's POST handler in MvcController
+    customer1DepositFormInputs.setAmountToDeposit(CUSTOMER1_AMOUNT_TO_DEPOSIT);
+    controller.submitDeposit(customer1DepositFormInputs);
+
+    // store timestamp of when Deposit request is sent to verify timestamps in the
+    // TransactionHistory table later
+    LocalDateTime timeWhenDepositRequestSent = MvcControllerIntegTestHelpers
+        .fetchCurrentTimeAsLocalDateTimeNoMilliseconds();
+    System.out.println("Timestamp when Deposit Request is sent: " + timeWhenDepositRequestSent);
+
+    // fetch updated data from the DB
+    List<Map<String, Object>> customersTableData = jdbcTemplate.queryForList("SELECT * FROM Customers;");
+    List<Map<String, Object>> transactionHistoryTableData = jdbcTemplate
+        .queryForList("SELECT * FROM TransactionHistory;");
+
+    // verify that customer1's data is still the only data populated in Customers
+    // table
+    assertEquals(1, customersTableData.size());
+    Map<String, Object> customer1Data = customersTableData.get(0);
+    assertEquals(CUSTOMER1_ID, (String) customer1Data.get("CustomerID"));
+
+    // verify customer balance was increased by $35.30 ($20 + $15.30) due to deposit
+    // and applying interest
+    double CUSTOMER1_EXPECTED_FINAL_BALANCE = CUSTOMER1_BALANCE +
+        CUSTOMER1_AMOUNT_TO_DEPOSIT + CUSTOMER1_INTEREST;
+    double CUSTOMER1_EXPECTED_FINAL_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers
+        .convertDollarsToPennies(CUSTOMER1_EXPECTED_FINAL_BALANCE);
+    assertEquals(CUSTOMER1_EXPECTED_FINAL_BALANCE_IN_PENNIES, (int) customer1Data.get("Balance"));
+
+    // verify that the Deposit and ApplyInterest are the only logs in
+    // TransactionHistory table
+    assertEquals(2, transactionHistoryTableData.size());
+
+    // verify that the Deposit's details are accurately logged in the
+    // TransactionHistory table
+    Map<String, Object> customer1TransactionLogDeposit = transactionHistoryTableData.get(0);
+    int CUSTOMER1_AMOUNT_TO_DEPOSIT_IN_PENNIES = MvcControllerIntegTestHelpers
+        .convertDollarsToPennies(CUSTOMER1_AMOUNT_TO_DEPOSIT);
+    MvcControllerIntegTestHelpers.checkTransactionLog(customer1TransactionLogDeposit, timeWhenDepositRequestSent,
+        CUSTOMER1_ID,
+        MvcController.TRANSACTION_HISTORY_DEPOSIT_ACTION, CUSTOMER1_AMOUNT_TO_DEPOSIT_IN_PENNIES);
+
+    // verify that the ApplyInterest's details are accurately logged in the
+    // TransactionHistory table
+    Map<String, Object> customer1TransactionLogApplyInterest = transactionHistoryTableData.get(1);
+    int CUSTOMER1_INTEREST_IN_PENNIES = MvcControllerIntegTestHelpers
+        .convertDollarsToPennies(CUSTOMER1_INTEREST);
+    MvcControllerIntegTestHelpers.checkTransactionLog(customer1TransactionLogApplyInterest, timeWhenDepositRequestSent,
+        CUSTOMER1_ID,
+        MvcController.TRANSACTION_HISTORY_APPLY_INTEREST_ACTION, CUSTOMER1_INTEREST_IN_PENNIES);
+  }
+
+  /**
+   * Test that after every five deposits, interest is applied to the balance.
+   * Also verifies that interest is being applied with only deposits of $20 and
+   * above.
+   * 
+   * @throws SQLException
+   * @throws ScriptException
+   */
+  @Test
+  public void testApplyInterestEveryFiveTransactions() throws SQLException, ScriptException {
+    // Initialize customer1 with a balance of $1000.11. Balance will be represented
+    // as
+    // pennies in DB.
+    double CUSTOMER1_BALANCE = 1000.11;
+    int CUSTOMER1_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_BALANCE);
+    MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME,
+        CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, 0);
+
+    // Prepare Deposit Form to Deposit money to customer 1's account. user input is
+    // in dollar
+    // amount, not pennies.
+    User customer1DepositFormInputs = new User();
+    customer1DepositFormInputs.setUsername(CUSTOMER1_ID);
+    customer1DepositFormInputs.setPassword(CUSTOMER1_PASSWORD);
+
+    // send 6 requests to the Deposit Form's POST handler in MvcController
+    customer1DepositFormInputs.setAmountToDeposit(20.00);
+    controller.submitDeposit(customer1DepositFormInputs);
+    customer1DepositFormInputs.setAmountToDeposit(20.01);
+    controller.submitDeposit(customer1DepositFormInputs);
+    customer1DepositFormInputs.setAmountToDeposit(30.00);
+    controller.submitDeposit(customer1DepositFormInputs);
+    customer1DepositFormInputs.setAmountToDeposit(30.00);
+    controller.submitDeposit(customer1DepositFormInputs);
+    customer1DepositFormInputs.setAmountToDeposit(100.00);
+    controller.submitDeposit(customer1DepositFormInputs);
+    customer1DepositFormInputs.setAmountToDeposit(20.01);
+    controller.submitDeposit(customer1DepositFormInputs);
+    customer1DepositFormInputs.setAmountToDeposit(19.99);
+    controller.submitDeposit(customer1DepositFormInputs);
+
+    // fetch updated data from the DB
+    List<Map<String, Object>> customersTableData = jdbcTemplate.queryForList("SELECT * FROM Customers;");
+    List<Map<String, Object>> transactionHistoryTableData = jdbcTemplate
+        .queryForList("SELECT * FROM TransactionHistory;");
+
+    // verify that there are 7 transactions in the TransactionHistory table (7
+    // deposits and 1 apply interest)
+    assertEquals(8, transactionHistoryTableData.size());
+
+    // verify that the deposits are accurately logged in the TransactionHistory
+    // table and the fifth transaction is ApplyInterest
+    Map<String, Object> customer1TransactionLogApplyInterest = transactionHistoryTableData.get(5);
+    assertEquals("ApplyInterest", (String) customer1TransactionLogApplyInterest.get("Action"));
+
+    // verify that the deposits after the fifth one do not apply interest
+    Map<String, Object> customer1TransactionLogSixthDeposit = transactionHistoryTableData.get(6);
+    assertEquals("Deposit", (String) customer1TransactionLogSixthDeposit.get("Action"));
+
+    // verify that the final deposit of 19.99 did not contribute to
+    // numDepositsForInterest and that numDepositsForInterest reset to 0 after the
+    // fifth deposit (is now 1 due to the sixth deposit of $20.01)
+    Map<String, Object> customer1Data = customersTableData.get(0);
+    assertEquals(1, (int) customer1Data.get("numDepositsForInterest"));
+
   }
 
 }

--- a/src/test/java/net/testudobank/tests/MvcControllerIntegTest.java
+++ b/src/test/java/net/testudobank/tests/MvcControllerIntegTest.java
@@ -1811,32 +1811,24 @@ public class MvcControllerIntegTest {
    */
   @Test
   public void testSimpleApplyInterest() throws SQLException, ScriptException {
-    // Initialize customer1 with a balance of $1000. Balance will be represented
-    // as pennies in DB.
     double CUSTOMER1_BALANCE = 1000;
     int CUSTOMER1_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_BALANCE);
     MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME,
         CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, 4);
 
-    // Prepare Deposit Form to Deposit money to customer 1's account. user input is
-    // in dollar amount, not pennies.
     User customer1DepositFormInputs = new User();
     customer1DepositFormInputs.setUsername(CUSTOMER1_ID);
     customer1DepositFormInputs.setPassword(CUSTOMER1_PASSWORD);
     double CUSTOMER1_AMOUNT_TO_DEPOSIT = 20.00;
     double CUSTOMER1_INTEREST = 15.30;
 
-    // send a request to the Deposit Form's POST handler in MvcController
     customer1DepositFormInputs.setAmountToDeposit(CUSTOMER1_AMOUNT_TO_DEPOSIT);
     controller.submitDeposit(customer1DepositFormInputs);
 
-    // store timestamp of when Deposit request is sent to verify timestamps in the
-    // TransactionHistory table later
     LocalDateTime timeWhenDepositRequestSent = MvcControllerIntegTestHelpers
         .fetchCurrentTimeAsLocalDateTimeNoMilliseconds();
     System.out.println("Timestamp when Deposit Request is sent: " + timeWhenDepositRequestSent);
 
-    // fetch updated data from the DB
     List<Map<String, Object>> customersTableData = jdbcTemplate.queryForList("SELECT * FROM Customers;");
     List<Map<String, Object>> transactionHistoryTableData = jdbcTemplate
         .queryForList("SELECT * FROM TransactionHistory;");
@@ -1855,8 +1847,6 @@ public class MvcControllerIntegTest {
         .convertDollarsToPennies(CUSTOMER1_EXPECTED_FINAL_BALANCE);
     assertEquals(CUSTOMER1_EXPECTED_FINAL_BALANCE_IN_PENNIES, (int) customer1Data.get("Balance"));
 
-    // verify that the Deposit and ApplyInterest are the only logs in
-    // TransactionHistory table
     assertEquals(2, transactionHistoryTableData.size());
 
     // verify that the Deposit's details are accurately logged in the
@@ -1888,22 +1878,15 @@ public class MvcControllerIntegTest {
    */
   @Test
   public void testApplyInterestEveryFiveTransactions() throws SQLException, ScriptException {
-    // Initialize customer1 with a balance of $1000.11. Balance will be represented
-    // as
-    // pennies in DB.
     double CUSTOMER1_BALANCE = 1000.11;
     int CUSTOMER1_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers.convertDollarsToPennies(CUSTOMER1_BALANCE);
     MvcControllerIntegTestHelpers.addCustomerToDB(dbDelegate, CUSTOMER1_ID, CUSTOMER1_PASSWORD, CUSTOMER1_FIRST_NAME,
         CUSTOMER1_LAST_NAME, CUSTOMER1_BALANCE_IN_PENNIES, 0);
 
-    // Prepare Deposit Form to Deposit money to customer 1's account. user input is
-    // in dollar
-    // amount, not pennies.
     User customer1DepositFormInputs = new User();
     customer1DepositFormInputs.setUsername(CUSTOMER1_ID);
     customer1DepositFormInputs.setPassword(CUSTOMER1_PASSWORD);
 
-    // send 6 requests to the Deposit Form's POST handler in MvcController
     customer1DepositFormInputs.setAmountToDeposit(20.00);
     controller.submitDeposit(customer1DepositFormInputs);
     customer1DepositFormInputs.setAmountToDeposit(20.01);
@@ -1919,7 +1902,6 @@ public class MvcControllerIntegTest {
     customer1DepositFormInputs.setAmountToDeposit(19.99);
     controller.submitDeposit(customer1DepositFormInputs);
 
-    // fetch updated data from the DB
     List<Map<String, Object>> customersTableData = jdbcTemplate.queryForList("SELECT * FROM Customers;");
     List<Map<String, Object>> transactionHistoryTableData = jdbcTemplate
         .queryForList("SELECT * FROM TransactionHistory;");

--- a/src/test/java/net/testudobank/tests/MvcControllerIntegTest.java
+++ b/src/test/java/net/testudobank/tests/MvcControllerIntegTest.java
@@ -1833,14 +1833,12 @@ public class MvcControllerIntegTest {
     List<Map<String, Object>> transactionHistoryTableData = jdbcTemplate
         .queryForList("SELECT * FROM TransactionHistory;");
 
-    // verify that customer1's data is still the only data populated in Customers
-    // table
+    // verify that customer1's data is still the only data populated in Customers table
     assertEquals(1, customersTableData.size());
     Map<String, Object> customer1Data = customersTableData.get(0);
     assertEquals(CUSTOMER1_ID, (String) customer1Data.get("CustomerID"));
 
-    // verify customer balance was increased by $35.30 ($20 + $15.30) due to deposit
-    // and applying interest
+    // verify customer balance was increased by $35.30 ($20 + $15.30) due to deposit and applying interest
     double CUSTOMER1_EXPECTED_FINAL_BALANCE = CUSTOMER1_BALANCE +
         CUSTOMER1_AMOUNT_TO_DEPOSIT + CUSTOMER1_INTEREST;
     double CUSTOMER1_EXPECTED_FINAL_BALANCE_IN_PENNIES = MvcControllerIntegTestHelpers
@@ -1849,8 +1847,7 @@ public class MvcControllerIntegTest {
 
     assertEquals(2, transactionHistoryTableData.size());
 
-    // verify that the Deposit's details are accurately logged in the
-    // TransactionHistory table
+    // verify that transacrtions are accurately logged in the TransactionHistory table
     Map<String, Object> customer1TransactionLogDeposit = transactionHistoryTableData.get(0);
     int CUSTOMER1_AMOUNT_TO_DEPOSIT_IN_PENNIES = MvcControllerIntegTestHelpers
         .convertDollarsToPennies(CUSTOMER1_AMOUNT_TO_DEPOSIT);
@@ -1858,8 +1855,6 @@ public class MvcControllerIntegTest {
         CUSTOMER1_ID,
         MvcController.TRANSACTION_HISTORY_DEPOSIT_ACTION, CUSTOMER1_AMOUNT_TO_DEPOSIT_IN_PENNIES);
 
-    // verify that the ApplyInterest's details are accurately logged in the
-    // TransactionHistory table
     Map<String, Object> customer1TransactionLogApplyInterest = transactionHistoryTableData.get(1);
     int CUSTOMER1_INTEREST_IN_PENNIES = MvcControllerIntegTestHelpers
         .convertDollarsToPennies(CUSTOMER1_INTEREST);
@@ -1906,12 +1901,9 @@ public class MvcControllerIntegTest {
     List<Map<String, Object>> transactionHistoryTableData = jdbcTemplate
         .queryForList("SELECT * FROM TransactionHistory;");
 
-    // verify that there are 7 transactions in the TransactionHistory table (7
-    // deposits and 1 apply interest)
     assertEquals(8, transactionHistoryTableData.size());
 
-    // verify that the deposits are accurately logged in the TransactionHistory
-    // table and the fifth transaction is ApplyInterest
+    // verify that the deposits are accurately logged in the TransactionHistory table
     Map<String, Object> customer1TransactionLogApplyInterest = transactionHistoryTableData.get(5);
     assertEquals("ApplyInterest", (String) customer1TransactionLogApplyInterest.get("Action"));
 


### PR DESCRIPTION
**Changes Made in this PR:**

I added a feature that applies a 1.5% APY interest rate to a customer's balance after every five deposits that are $20 or greater. This feature will reward customers for consistently using Testudo Bank and incentivize them to continue using this bank to store their money. 

<hr>

`src/main/java/net/testudobank/MvcController.java
`

- Verifies that deposit is $20 or more
- Checks that customer balance is not zero and customer is not in overdraft
- In order to keep track of the number of valid deposits for applying interest, `numDeposits` is incremented with every deposit that is $20 or more. On every fifth deposit, `numDeposit` is reset to 0
- On every fifth deposit, the 1.5% APY interest rate is applied to the new balance and a new row is added to the Transaction History Table to log the ApplyInterest action

<hr>

`src/test/java/net/testudobank/tests/MvcControllerIntegTest.java`

- Added a test `testSimpleApplyInterest` which verifies that interest is applied correctly to the customer's balance after the fifth deposit that is $20 or more. Also verifies that the correct logs are added to the Transaction History Table
- Added a test `testApplyInterestEveryFiveTransactions` which verifies that interest is applied every five deposits and that interest is not being applied after the fifth. Also verifies that interest is being applied for only deposits of $20 or more. 
- Added a test `testApplyInterestOverdraft` which verifies customers that are in overdraft are excluded from gaining interest on their balance.
- Added a test `testApplyInterestInsufficientBalance` which verifies customers that have no balance are excluded from gaining interest on their balance.

<hr>

`src/test/java/net/testudobank/helpers/MvcControllerIntegTestHelpers.java
`

- Fixed a bug in `addCustomerToDB` where 0 was being passed in for the argument `interestDeposits` instead of the actual number of interest deposits